### PR TITLE
Added worker thread to deal with heartbeats & sending metrics/events

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/simvue-io/client",
     platforms=["any"],
-    install_requires=["requests", "randomname"],
+    install_requires=["requests", "randomname", "msgpack"],
     package_dir={'': '.'},
     packages=['simvue'],
     package_data={"": ["README.md"]},

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/simvue-io/client",
     platforms=["any"],
-    install_requires=["requests", "randomname", "msgpack"],
+    install_requires=["requests", "randomname", "msgpack", "tenacity"],
     package_dir={'': '.'},
     packages=['simvue'],
     package_data={"": ["README.md"]},

--- a/simvue/client.py
+++ b/simvue/client.py
@@ -83,8 +83,8 @@ class Simvue(object):
         self._data = []
         self._events = []
         self._step = 0
-        self._metrics_queue = multiprocessing.JoinableQueue(maxsize=QUEUE_SIZE)
-        self._events_queue = multiprocessing.JoinableQueue(maxsize=QUEUE_SIZE)
+        self._metrics_queue = multiprocessing.Manager().Queue(maxsize=QUEUE_SIZE)
+        self._events_queue = multiprocessing.Manager().Queue(maxsize=QUEUE_SIZE)
 
     def __enter__(self):
         return self

--- a/simvue/client.py
+++ b/simvue/client.py
@@ -16,6 +16,9 @@ import randomname
 import threading
 
 INIT_MISSING = 'initialize a run using init() first'
+QUEUE_SIZE = 1000
+HEARTBEAT_INTERVAL = 60
+POLLING_INTERVAL = 2
 
 class Worker(threading.Thread):
     def __init__(self, metrics_queue, events_queue, name, url, headers):
@@ -31,7 +34,7 @@ class Worker(threading.Thread):
         last_heartbeat = 0
         while True:
             # Send heartbeat
-            if time.time() - last_heartbeat > 60:
+            if time.time() - last_heartbeat > HEARTBEAT_INTERVAL:
                 try:
                     requests.put('%s/api/runs/heartbeat' % self._url, headers=self._headers, json={'name': self._name})
                     last_heartbeat = time.time()
@@ -73,7 +76,7 @@ class Worker(threading.Thread):
             if not self._parent_thread.is_alive():
                 sys.exit(0)
 
-            time.sleep(2)
+            time.sleep(POLLING_INTERVAL)
 
 def get_cpu_info():
     """
@@ -151,8 +154,8 @@ class Simvue(object):
         self._data = []
         self._events = []
         self._step = 0
-        self._metrics_queue = multiprocessing.JoinableQueue(maxsize=1000)
-        self._events_queue = multiprocessing.JoinableQueue(maxsize=1000)
+        self._metrics_queue = multiprocessing.JoinableQueue(maxsize=QUEUE_SIZE)
+        self._events_queue = multiprocessing.JoinableQueue(maxsize=QUEUE_SIZE)
 
         # Try environment variables
         token = os.getenv('SIMVUE_TOKEN')

--- a/simvue/client.py
+++ b/simvue/client.py
@@ -76,6 +76,15 @@ class Simvue(object):
     """
     def __init__(self):
         self._name = None
+        self._suppress_errors = False
+        self._status = None
+        self._upload_time_log = None
+        self._upload_time_event = None
+        self._data = []
+        self._events = []
+        self._step = 0
+        self._metrics_queue = multiprocessing.JoinableQueue(maxsize=QUEUE_SIZE)
+        self._events_queue = multiprocessing.JoinableQueue(maxsize=QUEUE_SIZE)
 
     def __enter__(self):
         return self
@@ -88,16 +97,6 @@ class Simvue(object):
         """
         Initialise a run
         """
-        self._suppress_errors = False
-        self._status = None
-        self._upload_time_log = None
-        self._upload_time_event = None
-        self._data = []
-        self._events = []
-        self._step = 0
-        self._metrics_queue = multiprocessing.JoinableQueue(maxsize=QUEUE_SIZE)
-        self._events_queue = multiprocessing.JoinableQueue(maxsize=QUEUE_SIZE)
-
         # Try environment variables
         token = os.getenv('SIMVUE_TOKEN')
         self._url = os.getenv('SIMVUE_URL')

--- a/simvue/client.py
+++ b/simvue/client.py
@@ -45,7 +45,9 @@ def get_gpu_info():
     Get GPU info
     """
     try:
-        output = subprocess.check_output(["nvidia-smi", "--query-gpu=name,driver_version", "--format=csv"])
+        output = subprocess.check_output(["nvidia-smi",
+                                          "--query-gpu=name,driver_version",
+                                          "--format=csv"])
         lines = output.split(b'\n')
         tokens = lines[1].split(b', ')
     except Exception:

--- a/simvue/client.py
+++ b/simvue/client.py
@@ -5,13 +5,13 @@ import logging
 import mimetypes
 import os
 import re
-import requests
 import multiprocessing
 import socket
 import subprocess
 import sys
 import time
 import platform
+import requests
 import randomname
 
 from .worker import Worker

--- a/simvue/client.py
+++ b/simvue/client.py
@@ -231,7 +231,7 @@ class Simvue(object):
         data['timestamp'] = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')
 
         try:
-            self._events_queue.put(data, block=queue_blocking)
+            self._events_queue.put(data, block=self._queue_blocking)
         except multiprocessing.queue.Full:
             pass
 
@@ -260,7 +260,7 @@ class Simvue(object):
         self._step += 1
 
         try:
-            self._metrics_queue.put(data, block=queue_blocking)
+            self._metrics_queue.put(data, block=self._queue_blocking)
         except multiprocessing.queue.Full:
             pass
 

--- a/simvue/client.py
+++ b/simvue/client.py
@@ -15,7 +15,7 @@ import platform
 import randomname
 import threading
 
-SIMVUE_INIT_MISSING = 'initialize a run using init() first'
+INIT_MISSING = 'initialize a run using init() first'
 
 class Worker(threading.Thread):
     def __init__(self, metrics_queue, events_queue, name, url, headers):
@@ -251,7 +251,7 @@ class Simvue(object):
         Add/update metadata
         """
         if not self._name:
-            raise RuntimeError(SIMVUE_INIT_MISSING)
+            raise RuntimeError(INIT_MISSING)
 
         if not isinstance(metadata, dict):
             raise RuntimeError('metadata must be a dict')
@@ -273,7 +273,7 @@ class Simvue(object):
         Write event
         """
         if not self._name:
-            raise RuntimeError(SIMVUE_INIT_MISSING)
+            raise RuntimeError(INIT_MISSING)
 
         if self._status:
             raise RuntimeError('Cannot log events after run has ended')
@@ -295,7 +295,7 @@ class Simvue(object):
         Write metrics
         """
         if not self._name:
-            raise RuntimeError(SIMVUE_INIT_MISSING)
+            raise RuntimeError(INIT_MISSING)
 
         if self._status:
             raise RuntimeError('Cannot log metrics after run has ended')
@@ -324,7 +324,7 @@ class Simvue(object):
         Upload file
         """
         if not self._name:
-            raise RuntimeError(SIMVUE_INIT_MISSING)
+            raise RuntimeError(INIT_MISSING)
 
         if not os.path.isfile(filename):
             raise RuntimeError('File %s does not exist' % filename)

--- a/simvue/client.py
+++ b/simvue/client.py
@@ -77,6 +77,7 @@ class Simvue(object):
     def __init__(self):
         self._name = None
         self._suppress_errors = False
+        self._queue_blocking = False
         self._status = None
         self._upload_time_log = None
         self._upload_time_event = None
@@ -180,14 +181,17 @@ class Simvue(object):
 
         return True
 
-    def config(self, suppress_errors=False):
+    def config(self, suppress_errors=False, queue_blocking=False):
         """
         Optional configuration
         """
         if not isinstance(suppress_errors, bool):
             raise RuntimeError('suppress_errors must be boolean')
-
         self._suppress_errors = suppress_errors
+
+        if not isinstance(queue_blocking, bool):
+            raise RuntimeError('queue_blocking must be boolean')
+        self._queue_blocking = queue_blocking
 
     def update_metadata(self, metadata):
         """
@@ -227,7 +231,7 @@ class Simvue(object):
         data['timestamp'] = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')
 
         try:
-            self._events_queue.put(data, block=False)
+            self._events_queue.put(data, block=queue_blocking)
         except multiprocessing.queue.Full:
             pass
 
@@ -256,7 +260,7 @@ class Simvue(object):
         self._step += 1
 
         try:
-            self._metrics_queue.put(data, block=False)
+            self._metrics_queue.put(data, block=queue_blocking)
         except multiprocessing.queue.Full:
             pass
 

--- a/simvue/client.py
+++ b/simvue/client.py
@@ -45,7 +45,7 @@ class Worker(threading.Thread):
             buffer = []
             while not self._metrics_queue.empty():
                 try:
-                    item = self._metrics_queue.get()
+                    item = self._metrics_queue.get(block=False)
                     buffer.append(item)
                     self._metrics_queue.task_done()
                 except queue.Empty:
@@ -61,7 +61,7 @@ class Worker(threading.Thread):
             buffer = []
             while not self._events_queue.empty():
                 try:
-                    item = self._events_queue.get()
+                    item = self._events_queue.get(block=False)
                     buffer.append(item)
                     self._events_queue.task_done()
                 except queue.Empty:
@@ -287,7 +287,7 @@ class Simvue(object):
         data['timestamp'] = datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S.%f')
 
         try:
-            self._events_queue.put(data)
+            self._events_queue.put(data, block=False)
         except queue.Full:
             pass
 
@@ -316,7 +316,7 @@ class Simvue(object):
         self._step += 1
 
         try:
-            self._metrics_queue.put(data)
+            self._metrics_queue.put(data, block=False)
         except queue.Full:
             pass
 

--- a/simvue/client.py
+++ b/simvue/client.py
@@ -447,7 +447,7 @@ class SimvueHandler(logging.Handler):
             logging.Handler.handleError(self, record)
 
     def flush(self):
-       pass
+        pass
 
     def close(self):
         pass

--- a/simvue/client.py
+++ b/simvue/client.py
@@ -13,7 +13,6 @@ import sys
 import time
 import platform
 import randomname
-import threading
 
 from .worker import Worker
 

--- a/simvue/client.py
+++ b/simvue/client.py
@@ -17,7 +17,7 @@ import randomname
 from .worker import Worker
 
 INIT_MISSING = 'initialize a run using init() first'
-QUEUE_SIZE = 1000
+QUEUE_SIZE = 5000
 
 def get_cpu_info():
     """
@@ -228,7 +228,7 @@ class Simvue(object):
 
         try:
             self._events_queue.put(data, block=False)
-        except queue.Full:
+        except multiprocessing.queue.Full:
             pass
 
         return True
@@ -257,7 +257,7 @@ class Simvue(object):
 
         try:
             self._metrics_queue.put(data, block=False)
-        except queue.Full:
+        except multiprocessing.queue.Full:
             pass
 
         return True

--- a/simvue/client.py
+++ b/simvue/client.py
@@ -180,14 +180,14 @@ class Simvue(object):
 
         return True
 
-    def suppress_errors(self, value):
+    def config(self, suppress_errors=False):
         """
-        Specify if errors should raise exceptions or not
+        Optional configuration
         """
-        if not isinstance(value, bool):
-            raise RuntimeError('value must be boolean')
+        if not isinstance(suppress_errors, bool):
+            raise RuntimeError('suppress_errors must be boolean')
 
-        self._suppress_errors = value
+        self._suppress_errors = suppress_errors
 
     def update_metadata(self, metadata):
         """

--- a/simvue/worker.py
+++ b/simvue/worker.py
@@ -1,4 +1,3 @@
-import multiprocessing
 import sys
 import time
 import threading
@@ -26,15 +25,19 @@ class Worker(threading.Thread):
         """
         Send a heartbeat, with retries
         """
-        response = requests.put('%s/api/runs/heartbeat' % self._url, headers=self._headers, json={'name': self._name})
+        response = requests.put('%s/api/runs/heartbeat' % self._url,
+                                headers=self._headers,
+                                json={'name': self._name})
         response.raise_for_status()
-   
+
     @retry(wait=wait_exponential(multiplier=1, min=4, max=10), stop=stop_after_attempt(5))
     def post(self, endpoint, data):
         """
         Send the supplied data, with retries
         """
-        response = requests.post('%s/api/%s' % (self._url, endpoint), headers=self._headers_mp, data=data)
+        response = requests.post('%s/api/%s' % (self._url, endpoint),
+                                 headers=self._headers_mp,
+                                 data=data)
         response.raise_for_status()
 
     def run(self):
@@ -50,7 +53,6 @@ class Worker(threading.Thread):
                 except:
                     pass
                 last_heartbeat = time.time()
-   
 
             # Send metrics
             buffer = []

--- a/simvue/worker.py
+++ b/simvue/worker.py
@@ -23,15 +23,24 @@ class Worker(threading.Thread):
 
     @retry(wait=wait_exponential(multiplier=1, min=4, max=10), stop=stop_after_attempt(5))
     def heartbeat(self):
+        """
+        Send a heartbeat, with retries
+        """
         response = requests.put('%s/api/runs/heartbeat' % self._url, headers=self._headers, json={'name': self._name})
         response.raise_for_status()
    
     @retry(wait=wait_exponential(multiplier=1, min=4, max=10), stop=stop_after_attempt(5))
     def post(self, endpoint, data):
+        """
+        Send the supplied data, with retries
+        """
         response = requests.post('%s/api/%s' % (self._url, endpoint), headers=self._headers_mp, data=data)
         response.raise_for_status()
 
     def run(self):
+        """
+        Loop sending heartbeats, metrics and events
+        """
         last_heartbeat = 0
         while True:
             # Send heartbeat

--- a/simvue/worker.py
+++ b/simvue/worker.py
@@ -6,7 +6,7 @@ import requests
 import msgpack
 
 HEARTBEAT_INTERVAL = 60
-POLLING_INTERVAL = 2
+POLLING_INTERVAL = 1
 
 class Worker(threading.Thread):
     def __init__(self, metrics_queue, events_queue, name, url, headers):

--- a/simvue/worker.py
+++ b/simvue/worker.py
@@ -1,0 +1,60 @@
+import multiprocessing
+import sys
+import time
+import threading
+import requests
+
+HEARTBEAT_INTERVAL = 60
+POLLING_INTERVAL = 2
+
+class Worker(threading.Thread):
+    def __init__(self, metrics_queue, events_queue, name, url, headers):
+        threading.Thread.__init__(self)
+        self._parent_thread = threading.currentThread()
+        self._metrics_queue = metrics_queue
+        self._events_queue = events_queue
+        self._name = name
+        self._url = url
+        self._headers = headers
+
+    def run(self):
+        last_heartbeat = 0
+        while True:
+            # Send heartbeat
+            if time.time() - last_heartbeat > HEARTBEAT_INTERVAL:
+                try:
+                    requests.put('%s/api/runs/heartbeat' % self._url, headers=self._headers, json={'name': self._name})
+                    last_heartbeat = time.time()
+                except:
+                    pass
+
+            # Send metrics
+            buffer = []
+            while not self._metrics_queue.empty():
+                item = self._metrics_queue.get(block=False)
+                buffer.append(item)
+                self._metrics_queue.task_done()
+
+            if buffer:
+                try:
+                    response = requests.post('%s/api/metrics' % self._url, headers=self._headers, json=buffer)
+                except:
+                    pass
+
+            # Send events
+            buffer = []
+            while not self._events_queue.empty():
+                item = self._events_queue.get(block=False)
+                buffer.append(item)
+                self._events_queue.task_done()
+
+            if buffer:
+                try:
+                    requests.post('%s/api/events' % self._url, headers=self._headers, json=buffer)
+                except:
+                    pass
+
+            if not self._parent_thread.is_alive():
+                sys.exit(0)
+
+            time.sleep(POLLING_INTERVAL)

--- a/simvue/worker.py
+++ b/simvue/worker.py
@@ -59,6 +59,7 @@ class Worker(threading.Thread):
                     pass
 
             if not self._parent_thread.is_alive():
-                sys.exit(0)
-
-            time.sleep(POLLING_INTERVAL)
+                if self._metrics_queue.empty() and self._events_queue.empty():
+                    sys.exit(0)
+            else:
+                time.sleep(POLLING_INTERVAL)

--- a/tests/unit/test_simvue.py
+++ b/tests/unit/test_simvue.py
@@ -8,5 +8,5 @@ def test_supress_errors():
 
     simv = client.Simvue()
 
-    with pytest.raises(RuntimeError, match="value must be boolean"):
+    with pytest.raises(RuntimeError, match="suppress_errors must be boolean"):
         simv.config(suppress_errors=200)

--- a/tests/unit/test_simvue.py
+++ b/tests/unit/test_simvue.py
@@ -9,4 +9,4 @@ def test_supress_errors():
     simv = client.Simvue()
 
     with pytest.raises(RuntimeError, match="value must be boolean"):
-        simv.suppress_errors(200)
+        simv.config(suppress_errors=200)


### PR DESCRIPTION
A single worker thread is created which sends heartbeats at regular intervals as well as sending metrics & events. The main thread adds metrics/events to a queue, and the data is uploaded to the server in batches. When the main thread is finished the worker thread sends any remaining data and then exits.

Also here msgpack is used to compress the JSON before upload.