### PR TITLE
Reverts to using `Union` for typing

### DIFF
--- a/simvue/executor.py
+++ b/simvue/executor.py
@@ -54,9 +54,9 @@ class Executor:
         self,
         identifier: str,
         *args,
-        executable: str | None = None,
-        script: str | None = None,
-        input_file: str | None = None,
+        executable: typing.Optional[str]= None,
+        script: typing.Optional[str]= None,
+        input_file: typing.Optional[str]= None,
         **kwargs,
     ) -> None:
         """Add a process to be executed to the executor.

--- a/simvue/run.py
+++ b/simvue/run.py
@@ -350,9 +350,9 @@ class Run(object):
     def add_process(self,
         identifier: str,
         *cmd_args,
-        executable: str | None = None,
-        script: str | None = None,
-        input_file: str | None = None,
+        executable: typing.Optional[str]= None,
+        script: typing.Optional[str]= None,
+        input_file: typing.Optional[str]= None,
         **cmd_kwargs
     ) -> None:
         """Add a process to be executed to the executor.


### PR DESCRIPTION
As `|` is not supported for typing in Python < 3.10 references to this have been replaced with `Union`.

Closes #141 