### PR TITLE
Add Git Hooks via Pre-Commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,39 @@
+exclude: '^tests|^docs'
+repos:
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        name: isort (python)
+        args: ["--profile", "black"]
+  - repo: https://github.com/psf/black
+    rev: 24.2.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-toml
+      - id: check-yaml
+      - id: pretty-format-json
+        args: [--autofix]
+      - id: trailing-whitespace
+        language: python
+      - id: check-merge-conflict
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: no-commit-to-branch
+        args: [--branch, main, --branch, dev]
+      - id: check-added-large-files
+
+  - repo: https://github.com/conorfalvey/check_pdb_hook
+    rev: 0.0.9
+    hooks:
+      - id: check_pdb_hook
+        pass_filenames: false
+
+  - repo: https://github.com/PyCQA/bandit.git
+    rev: 1.7.7
+    hooks:
+    -   id: bandit
+        args: [-lll, --recursive, clumper]


### PR DESCRIPTION
Adds pre-commit Git hooks via the `pre-commit` tool. To use these install `pre-commit`:

```
pip install --user pre-commit
```
and run:

`pre-commit install`