### PR TITLE
Hotfix for deadlocking processes

### DIFF
--- a/simvue/executor.py
+++ b/simvue/executor.py
@@ -57,7 +57,6 @@ class Executor:
         executable: typing.Optional[str] = None,
         script: typing.Optional[str] = None,
         input_file: typing.Optional[str] = None,
-        print_stdout: bool = False,
         env: typing.Optional[typing.Dict[str, str]] = None,
         completion_callback: typing.Optional[
             typing.Callable[[int, str, str], None]
@@ -95,8 +94,6 @@ class Executor:
         ----------
         identifier : str
             A unique identifier for this process
-        print_stdout : bool, optional
-            print output of command to stdout
         executable : str | None, optional
             the main executable for the command, if not specified this is taken to be the first
             positional argument, by default None
@@ -140,36 +137,17 @@ class Executor:
             run_on_exit: typing.Optional[
                 typing.Callable[[int, int, str], None]
             ] = completion_callback,
-            print_out: bool = print_stdout,
             environment: typing.Optional[typing.Dict[str, str]] = env,
         ) -> None:
-            _logger = logging.getLogger(proc_id)
             with open(f"{runner.name}_{proc_id}.err", "w") as err:
                 with open(f"{runner.name}_{proc_id}.out", "w") as out:
                     _result = subprocess.Popen(
                         command,
-                        stdout=subprocess.PIPE,
-                        stderr=subprocess.PIPE,
+                        stdout=out,
+                        stderr=err,
                         universal_newlines=True,
                         env=environment,
                     )
-
-                    while True:
-                        _std_out_line = _result.stdout.readline()
-                        _std_err_line = _result.stderr.readline()
-
-                        if _std_out_line:
-                            out.write(_std_out_line)
-                            if print_out:
-                                _logger.info(_std_out_line)
-
-                        if _std_err_line:
-                            err.write(_std_err_line)
-                            if print_out:
-                                _logger.error(_std_err_line)
-
-                        if not _std_err_line and not _std_out_line:
-                            break
 
             _status_code = _result.wait()
 

--- a/simvue/executor.py
+++ b/simvue/executor.py
@@ -31,7 +31,7 @@ class Executor:
     being used to set the relevant metadata within the Simvue run itself.
     """
 
-    def __init__(self, simvue_runner: "simvue.Run", keep_logs: bool = False) -> None:
+    def __init__(self, simvue_runner: "simvue.Run", keep_logs: bool = True) -> None:
         """Initialise an instance of the Simvue executor attaching it to a Run.
 
         Parameters

--- a/simvue/run.py
+++ b/simvue/run.py
@@ -396,7 +396,6 @@ class Run(object):
         executable: typing.Optional[str] = None,
         script: typing.Optional[str] = None,
         input_file: typing.Optional[str] = None,
-        print_stdout: bool = False,
         completion_callback: typing.Optional[
             typing.Callable[[int, int, str], None]
         ] = None,
@@ -445,8 +444,6 @@ class Run(object):
         input_file : str | None, optional
             the input file to run, note this only work if the input file is not an option, if this is the case
             you should provide it as such and perform the upload manually, by default None
-        print_stdout : bool, optional
-            print output of command to the terminal, default is False
         completion_callback : typing.Callable | None, optional
             callback to run when process terminates
         env : typing.Dict[str, str], optional
@@ -490,7 +487,6 @@ class Run(object):
             executable=executable,
             script=script,
             input_file=input_file,
-            print_stdout=print_stdout,
             completion_callback=completion_callback,
             env=env,
             **cmd_kwargs,


### PR DESCRIPTION
Removed print to stdout to fix process deadlocking issue

Previously, process passed stdout and stderr to a `subprocess.PIPE`, and then this would be read using `_result.stdout.readline()` and `_result.stdout.readline()`, which was then added to a file and logged to the console if necessary. However, `.readline()` waits for the process to be complete, before writing everything at once. This meant that print to stdout wasn't working anyway.

More importantly, all of the stdout and stderr was being added to a buffer while the process continued. If you had a process which created a lot of stdout messages (MOOSE for example), then this buffer would fill up and the process would lock up. The process would never complete, and would hang indefinitely.

The current fix is to remove the print_stdout option, and instead have stdout and stderr from the process passed directly to a file. This means that it is not buffered, so you do not get the locking issue. 

Also set `keep_logs` to True by default - I think this makes the most sense, since otherwise users will see log files being created and then disappearing once the process is complete. It also avoids the issue that if the process was cancelled by the user mid way through, the log file would remain on the local system anyway

This somewhat addresses #233 and #234, but should only be a temporary fix. In the future it would be good to have the print_stdout option, but for now it is broken and not trivial to implement, so imo is best to remove.