### PR TITLE
Remove unused parametrize fixture from test

### DIFF
--- a/tests/refactor/test_run_class.py
+++ b/tests/refactor/test_run_class.py
@@ -15,7 +15,6 @@ if typing.TYPE_CHECKING:
 
 @pytest.mark.run
 @pytest.mark.parametrize("overload_buffer", (True, False), ids=("overload", "normal"))
-@pytest.mark.parametrize("heartbeat", (True, False))
 def test_log_metrics(
     create_plain_run: tuple[sv_run.Run, dict],
     overload_buffer: bool,


### PR DESCRIPTION
Removes a `parametrize` call that is not used and us not handled so breaks the test setup