### PR TITLE
Fix issue whereby resource metric logging affects user metric logging steps

### DIFF
--- a/simvue/run.py
+++ b/simvue/run.py
@@ -172,7 +172,7 @@ class Run:
                 for item in gpu:
                     data[item] = gpu[item]
 
-            self._add_metrics_to_dispatch(data)
+            self._add_metrics_to_dispatch(data, step=0)
 
     def _create_callback(
         self,

--- a/simvue/run.py
+++ b/simvue/run.py
@@ -172,7 +172,9 @@ class Run:
                 for item in gpu:
                     data[item] = gpu[item]
 
-            self._add_metrics_to_dispatch(data, step=0)
+            self._add_metrics_to_dispatch(
+                data, step=0
+            )  # Hard coded step to 0 for resource metrics so that user logged metrics dont appear to 'skip' steps
 
     def _create_callback(
         self,

--- a/simvue/run.py
+++ b/simvue/run.py
@@ -48,6 +48,7 @@ INIT_MISSING = "initialize a run using init() first"
 QUEUE_SIZE = 10000
 UPLOAD_TIMEOUT = 30
 HEARTBEAT_INTERVAL: int = 60
+RESOURCES_METRIC_PREFIX: str = "resources"
 
 logger = logging.getLogger(__name__)
 
@@ -164,14 +165,14 @@ class Run:
             data = {}
 
             data = {
-                "resources/cpu.usage.percent": cpu,
-                "resources/memory.usage": memory,
+                f"{RESOURCES_METRIC_PREFIX}/cpu.usage.percent": cpu,
+                f"{RESOURCES_METRIC_PREFIX}/memory.usage": memory,
             }
             if gpu:
                 for item in gpu:
                     data[item] = gpu[item]
 
-            self.log_metrics(data)
+            self._add_metrics_to_dispatch(data)
 
     def _create_callback(
         self,
@@ -676,10 +677,7 @@ class Run:
 
         return True
 
-    def log_metrics(self, metrics, step=None, time=None, timestamp=None):
-        """
-        Write metrics
-        """
+    def _add_metrics_to_dispatch(self, metrics, step=None, time=None, timestamp=None):
         if self._mode == "disabled":
             return True
 
@@ -710,9 +708,17 @@ class Run:
             "step": step or self._step,
         }
         self._dispatcher.add_item(_data, "metrics", self._queue_blocking)
-        self._step += 1
 
         return True
+
+    def log_metrics(self, metrics, step=None, time=None, timestamp=None):
+        """
+        Write metrics
+        """
+        self._add_metrics_to_dispatch(
+            metrics, step=step, time=time, timestamp=timestamp
+        )
+        self._step += 1
 
     def save(
         self,


### PR DESCRIPTION
Fixes a bug whereby the logging of resource metrics would increment the step leading to user metrics having uneven stepping.

This fix also addresses partially the issue where comparing a resource metric to a user metric on step axis showed all resource values to be at step zero. As the stepping of resource logging is different to user metric logging what now should happen is when plotting the two together for every user metric logged at a step, a set of 0-N points will be shown for the resources (i.e. all the resource metrics logged between the user step interval - "binned").