### PR TITLE
Use bash shell for windows CI tests

### DIFF
--- a/.github/workflows/test_client_windows.yml
+++ b/.github/workflows/test_client_windows.yml
@@ -21,6 +21,7 @@ jobs:
     - name: Install dependencies
       run: python -m pip install poetry
     - name: Test with pytest
+      shell: bash
       run: |
         export SIMVUE_URL=${{ secrets.SIMVUE_URL }}
         export SIMVUE_TOKEN=${{ secrets.SIMVUE_TOKEN }}


### PR DESCRIPTION
Addresses issue with `export` on Windows pipeline