### PR TITLE
Fix  sending of executor termination info via event with dispatcher

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,8 @@ markers = [
     "dispatch: test data dispatcher",
     "run: test the simvue Run class",
     "utilities: test simvue utilities module",
-    "scenario: test scenarios"
+    "scenario: test scenarios",
+    "executor: tests of executors"
 ]
 
 [tool.interrogate]

--- a/simvue/client.py
+++ b/simvue/client.py
@@ -1140,6 +1140,7 @@ class Client:
             "start": start_index or 0,
             "count": count_limit or 0,
         }
+        print(params)
 
         response = requests.get(
             f"{self._url}/api/events", headers=self._headers, params=params

--- a/simvue/executor.py
+++ b/simvue/executor.py
@@ -14,6 +14,7 @@ import logging
 import multiprocessing
 import os
 import subprocess
+import time
 import typing
 
 if typing.TYPE_CHECKING:
@@ -108,10 +109,6 @@ class Executor:
         completion_callback : typing.Callable | None, optional
             callback to run when process terminates
         """
-        _alert_kwargs = {
-            k.replace("__", ""): v for k, v in kwargs.items() if k.startswith("__")
-        }
-
         _pos_args = list(args)
 
         if script:
@@ -119,13 +116,6 @@ class Executor:
 
         if input_file:
             self._runner.save(filename=input_file, category="input")
-
-        self._runner.add_alert(
-            f"{identifier} Status",
-            source="events",
-            pattern="non-zero exit code",
-            **_alert_kwargs,
-        )
 
         def _exec_process(
             proc_id: str,
@@ -248,11 +238,27 @@ class Executor:
         """Send log events for the result of each process"""
         for proc_id, code in self._exit_codes.items():
             if code != 0:
+                # If the process fails then purge the dispatcher event queue
+                # and ensure that the stderr event is sent before the run closes
+                if self._runner._dispatcher:
+                    self._runner._dispatcher.purge()
+
                 _err = self._std_err[proc_id]
-                _msg = f"Process {proc_id} returned non-zero exit code status {code} with:\n{_err}"
+                _msg = f"Process {proc_id} returned non-zero exit status {code} with:\n{_err}"
             else:
                 _msg = f"Process {proc_id} completed successfully."
             self._runner.log_event(_msg)
+
+            # Wait for the dispatcher to send the latest information before
+            # allowing the executor to finish (and as such the run instance to exit)
+            _wait_limit: float = 1
+            _current_time: float = 0
+            while (
+                self._runner._dispatcher
+                and not self._runner._dispatcher.empty
+                and _current_time < _wait_limit
+            ):
+                time.sleep((_current_time := _current_time + 0.1))
 
     def _save_output(self) -> None:
         """Save the output to Simvue"""

--- a/simvue/run.py
+++ b/simvue/run.py
@@ -690,6 +690,7 @@ class Run:
         Write event
         """
         if self._mode == "disabled":
+            self._error("Cannot log events in 'disabled' state")
             return True
 
         if not self._uuid and not self._name:
@@ -710,6 +711,9 @@ class Run:
 
         _data = {"message": message, "timestamp": timestamp or self.time_stamp}
         self._dispatcher.add_item(_data, "events", self._queue_blocking)
+
+        # Need to stall the exit of Run so any executor events can be sent
+        time.sleep(1)
 
         return True
 

--- a/tests/refactor/test_executor.py
+++ b/tests/refactor/test_executor.py
@@ -1,0 +1,41 @@
+import pytest
+import simvue
+import time
+import os
+import shutil
+import tempfile
+
+
+@pytest.mark.executor
+@pytest.mark.parametrize("successful", (True, False), ids=("successful", "failing"))
+def test_executor_add_process(
+    successful: bool
+) -> None:
+    with tempfile.TemporaryDirectory() as temp_d:
+        if os.path.exists(_simvue_cfg := os.path.join(os.getcwd(), "simvue.ini")):
+            shutil.copy(_simvue_cfg, os.path.join(temp_d, "simvue.ini"))
+        elif os.path.exists(_simvue_cfg := os.path.join(os.environ["HOME"], ".simvue.ini")):
+            shutil.copy(_simvue_cfg, os.path.join(temp_d, "simvue.ini"))
+        _cwd = os.getcwd()
+        os.chdir(temp_d)
+        run = simvue.Run()
+        run.init(f"test_executor_{'success' if successful else 'fail'}", tags=["simvue_client_unit_tests"])
+        run.add_process(
+            identifier=f"test_add_process_{'success' if successful else 'fail'}",
+            c=f"exit {0 if successful else 1}",
+            executable="bash",
+        )
+        run.close()
+        os.chdir(_cwd)
+
+        if not successful:
+            assert run._executor.exit_status != 0
+        else:
+            assert run._executor.exit_status == 0
+        time.sleep(1)
+        client = simvue.Client()
+        _events = client.get_events(
+            run._id,
+            message_contains="successfully" if successful else "non-zero exit",
+        )
+        assert len(_events) == 1


### PR DESCRIPTION
Fixes a little bug where the dispatcher would purge/close the event queue before the executor's summary was sent.