### PR TITLE
Set run to lost and clear queue if Run in error state

### DIFF
--- a/simvue/utilities.py
+++ b/simvue/utilities.py
@@ -83,17 +83,13 @@ def skip_if_failed(
                 self, ignore_exc_attr, None
             ):
                 logger.debug(
-                    f"Skipping call to '{class_func.__name__}', client in fail state (see logs)."
+                    f"Skipping call to '{class_func.__name__}', "
+                    f"client in fail state (see logs)."
                 )
                 return on_failure_return
             return class_func(self, *args, **kwargs)
 
-        # Rename the wrapped function back to what it was called on
-        wrapper.__name__ = class_func.__name__
-
-        # To maintain a record of whether the function was wrapped
-        setattr(wrapper, "__skip_if_failed", True)
-
+        wrapper.__name__ = f"{class_func.__name__}__fail_safe"
         return wrapper
 
     return decorator


### PR DESCRIPTION
This fixes an issue whereby if the `Run` is set to dormant due to an exception throw and `suppress_errors=True` the metrics/events queue was not immediately purged as it should be. I also set the run to be shown as `lost` on Simvue as monitoring is no longer occuring.