### PR TITLE
Ensure thread completion on all pathways

### DIFF
--- a/simvue/client.py
+++ b/simvue/client.py
@@ -1129,7 +1129,7 @@ class Client:
         """
 
         msg_filter: str = (
-            json.dumps([f"event.message contains {message_contains}"])
+            json.dumps([{"operator": "contains", "value": message_contains}])
             if message_contains
             else ""
         )
@@ -1140,7 +1140,6 @@ class Client:
             "start": start_index or 0,
             "count": count_limit or 0,
         }
-        print(params)
 
         response = requests.get(
             f"{self._url}/api/events", headers=self._headers, params=params

--- a/simvue/executor.py
+++ b/simvue/executor.py
@@ -300,6 +300,7 @@ class Executor:
             process.join()
         self._log_events()
         self._save_output()
+
         if not self.success:
             self._runner.set_status("failed")
         self._clear_cache_files()


### PR DESCRIPTION
Also ensures that the `Executor` is waited for in `Run.close` as well as `Run.__exit__`.

This fixes an issue whereby threads were not joined/terminated gracefully if an exception was thrown likely leading to hanging behaviour.

In addition fixes `get_events` filter to match current server spec.