### PR TITLE
Remove use of shared run specs

### DIFF
--- a/tests/refactor/conftest.py
+++ b/tests/refactor/conftest.py
@@ -70,13 +70,14 @@ def create_plain_run_offline(mocker: pytest_mock.MockerFixture) -> typing.Genera
 
 
 def setup_test_run(run: sv_run.Run, create_objects: bool):
+    fix_use_id: str = str(uuid.uuid4()).split('-', 1)[0]
     TEST_DATA = {
         "event_contains": "sent event",
         "metadata": {
             "test_engine": "pytest",
-            "test_identifier": str(uuid.uuid4()).split('-', 1)[0]
+            "test_identifier": fix_use_id
         },
-        "folder": "/simvue_unit_testing"
+        "folder": f"/simvue_unit_testing/{fix_use_id}"
     }
     run.config(suppress_errors=False)
     run.init(
@@ -108,16 +109,16 @@ def setup_test_run(run: sv_run.Run, create_objects: bool):
     TEST_DATA["resources_metrics_interval"] = run._resources_metrics_interval
 
     if create_objects:
-        json.dump(TEST_DATA, open("test_attrs.json", "w"), indent=2)
-
         with tempfile.NamedTemporaryFile(suffix=".txt") as temp_f:
             with open(temp_f.name, "w") as out_f:
                 out_f.write("This is a test file")
             run.save(temp_f.name, category="input", name="test_file")
             TEST_DATA["file_1"] = "test_file"
 
-        run.save("test_attrs.json", category="output", name="test_attributes")
-        TEST_DATA["file_2"] = "test_attributes"
+        with tempfile.NamedTemporaryFile(suffix=".json") as temp_f: 
+            json.dump(TEST_DATA, open(f"test_attrs_{fix_use_id}.json", "w"), indent=2)
+            run.save(f"test_attrs_{fix_use_id}.json", category="output", name="test_attributes")
+            TEST_DATA["file_2"] = "test_attributes"
 
         with tempfile.NamedTemporaryFile(suffix=".py") as temp_f:
             with open(temp_f.name, "w") as out_f:

--- a/tests/refactor/test_client.py
+++ b/tests/refactor/test_client.py
@@ -166,26 +166,30 @@ PRE_DELETION_TESTS: list[str] = [
 
 @pytest.mark.dependency
 @pytest.mark.client(depends=PRE_DELETION_TESTS)
-def test_run_deletion() -> None:
-    test_data = json.load(open("test_attrs.json"))
+def test_run_deletion(create_test_run: tuple[sv_run.Run, dict]) -> None:
+    run, run_data = create_test_run
+    run.close()
     client = svc.Client()
-    assert not client.delete_run(test_data["run_id"])
+    assert not client.delete_run(run_data["run_id"])
 
 
 @pytest.mark.dependency
 @pytest.mark.client(depends=PRE_DELETION_TESTS)
-def test_runs_deletion() -> None:
-    test_data = json.load(open("test_attrs.json"))
+def test_runs_deletion(create_test_run: tuple[sv_run.Run, dict]) -> None:
+    run, run_data = create_test_run
+    run.update_tags(["simvue_client_unit_tests", "test_runs_deletion"])
+    run.close()
     client = svc.Client()
-    assert len(client.delete_runs(test_data["folder"])) > 0
+    assert len(client.delete_runs(run_data["folder"])) > 0
 
 
 @pytest.mark.dependency
 @pytest.mark.client(depends=PRE_DELETION_TESTS + ["test_runs_deletion"])
-def test_folder_deletion() -> None:
-    test_data = json.load(open(data_file := "test_attrs.json"))
+def test_folder_deletion(create_test_run: tuple[sv_run.Run, dict]) -> None:
+    run, run_data = create_test_run
+    run.update_tags(["simvue_client_unit_tests", "test_folder_deletion"])
+    run.close()
     client = svc.Client()
     # This test is called last, all runs should have been deleted by the above
     # test so this should be empty
-    assert not client.delete_folder(test_data["folder"], remove_runs=True, allow_missing=True)
-    os.remove(data_file)
+    assert not client.delete_folder(run_data["folder"], remove_runs=True)

--- a/tests/refactor/test_client.py
+++ b/tests/refactor/test_client.py
@@ -190,6 +190,5 @@ def test_folder_deletion(create_test_run: tuple[sv_run.Run, dict]) -> None:
     run.update_tags(["simvue_client_unit_tests", "test_folder_deletion"])
     run.close()
     client = svc.Client()
-    # This test is called last, all runs should have been deleted by the above
-    # test so this should be empty
-    assert not client.delete_folder(run_data["folder"], remove_runs=True)
+    # This test is called last, one run created so expect length 1
+    assert len(client.delete_folder(run_data["folder"], remove_runs=True)) == 1


### PR DESCRIPTION
Ensures all tests use their own created run as opposed to managing/deleting those potentially used by others