### PR TITLE
Set the default of `ttl` to be `None` and remove test files are completion

### DIFF
--- a/simvue/factory/proxy/remote.py
+++ b/simvue/factory/proxy/remote.py
@@ -334,8 +334,16 @@ class Remote(SimvueBaseClass):
             self._error(f"Got exception when listing alerts: {str(err)}")
             return []
 
+        if not (response_data := response.json()) or not (
+            data := response_data.get("data")
+        ):
+            self._error(
+                "Expected key 'data' in response from server during alert retrieval"
+            )
+            return []
+
         if response.status_code == 200:
-            return response.json()
+            return data
 
         return []
 

--- a/simvue/models.py
+++ b/simvue/models.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Dict, List, Optional, Union
 
-from pydantic import BaseModel, Field, StringConstraints
+from pydantic import BaseModel, Field, StringConstraints, PositiveInt
 
 FOLDER_REGEX: str = r"^/.*"
 NAME_REGEX: str = r"^[a-zA-Z0-9\-\_\s\/\.:]+$"
@@ -17,4 +17,4 @@ class RunInput(BaseModel):
     description: Optional[str] = None
     folder: str = Field(pattern=FOLDER_REGEX)
     status: Optional[str] = None
-    ttl: int
+    ttl: Optional[PositiveInt] = None

--- a/simvue/run.py
+++ b/simvue/run.py
@@ -381,7 +381,7 @@ class Run:
         description=None,
         folder="/",
         running=True,
-        ttl=-1,
+        ttl=None,
     ):
         """
         Initialise a run

--- a/tests/refactor/conftest.py
+++ b/tests/refactor/conftest.py
@@ -6,6 +6,8 @@ import time
 import tempfile
 import json
 import logging
+import pathlib
+import os
 import simvue.run as sv_run
 import simvue.utilities
 
@@ -42,8 +44,9 @@ def log_messages(caplog):
 @pytest.fixture
 def create_test_run() -> typing.Generator[typing.Tuple[sv_run.Run, dict], None, None]:
     with sv_run.Run() as run:
-        
         yield run, setup_test_run(run, True)
+    for file in pathlib.Path.cwd().glob("test_attrs*.json"):
+        os.remove(file)
 
 
 @pytest.fixture
@@ -52,12 +55,16 @@ def create_test_run_offline(mocker: pytest_mock.MockerFixture) -> typing.Generat
         mocker.patch.object(simvue.utilities, "get_offline_directory", lambda *_: temp_d)
         with sv_run.Run("offline") as run:
             yield run, setup_test_run(run, True)
+    for file in pathlib.Path.cwd().glob("test_attrs*.json"):
+        os.remove(file)
 
 
 @pytest.fixture
 def create_plain_run() -> typing.Generator[typing.Tuple[sv_run.Run, dict], None, None]:
     with sv_run.Run() as run:
         yield run, setup_test_run(run, False)
+    for file in pathlib.Path.cwd().glob("test_attrs*.json"):
+        os.remove(file)
 
 
 @pytest.fixture
@@ -67,7 +74,8 @@ def create_plain_run_offline(mocker: pytest_mock.MockerFixture) -> typing.Genera
         with sv_run.Run("offline") as run:
             
             yield run, setup_test_run(run, False)
-
+    for file in pathlib.Path.cwd().glob("test_attrs*.json"):
+        os.remove(file)
 
 def setup_test_run(run: sv_run.Run, create_objects: bool):
     fix_use_id: str = str(uuid.uuid4()).split('-', 1)[0]


### PR DESCRIPTION
Sets `ttl=None` as default during run initialisation and removes the `test_attrs*.json` files when tests have completed.