### PR TITLE
Add `empty` to dispatcher base class

### DIFF
--- a/simvue/factory/dispatch/base.py
+++ b/simvue/factory/dispatch/base.py
@@ -35,3 +35,8 @@ class DispatcherBaseClass(abc.ABC):
     @abc.abstractmethod
     def purge(self) -> None:
         pass
+
+    @property
+    @abc.abstractmethod
+    def empty(self) -> bool:
+        pass

--- a/simvue/factory/dispatch/direct.py
+++ b/simvue/factory/dispatch/direct.py
@@ -50,3 +50,8 @@ class DirectDispatcher(DispatcherBaseClass):
     def purge(self) -> None:
         """Purge does not execute anything in this context"""
         pass
+
+    @property
+    def empty(self) -> bool:
+        """No queue so always empty"""
+        return True


### PR DESCRIPTION
Adds the property `empty` to the Dispatcher base class to ensure interchangeability between dispatcher types.