### PR TITLE
Fail as `None` on token check

### DIFF
--- a/simvue/factory/proxy/remote.py
+++ b/simvue/factory/proxy/remote.py
@@ -429,7 +429,11 @@ class Remote(SimvueBaseClass):
         """
         Check token
         """
-        if time.time() - get_expiry(self._token) > 0:
+        if not (expiry := get_expiry(self._token)):
+            self._error("Failed to parse user token")
+            return False
+
+        if time.time() - expiry > 0:
             self._error("Token has expired")
             return False
         return True

--- a/simvue/utilities.py
+++ b/simvue/utilities.py
@@ -186,11 +186,11 @@ def remove_file(filename):
             logger.error("Unable to remove file %s due to: %s", filename, str(err))
 
 
-def get_expiry(token):
+def get_expiry(token) -> typing.Optional[int]:
     """
     Get expiry date from a JWT token
     """
-    expiry = 0
+    expiry: typing.Optional[int] = None
     with contextlib.suppress(jwt.DecodeError):
         expiry = jwt.decode(token, options={"verify_signature": False})["exp"]
 


### PR DESCRIPTION
Fixes bug whereby `0` was returned if the token could not be processed leading to token expiry errors instead of invalid token.