### PR TITLE
Refactor serialization and fix tuple without comma bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ if __name__ == "__main__":
                                description='This is part 1 of a test') # Description
 
         # Upload the code
-        run.save('training.py', 'code')
+        run.save_file('training.py', 'code')
 
         # Upload an input file
-        run.save('params.in', 'input')
+        run.save_file('params.in', 'input')
 
         # Add an alert (the alert definition will be created if necessary)
-        run.add_alert(name='loss-too-high',   # Name
+        run.create_alert(name='loss-too-high',   # Name
                       source='metrics',       # Source
                       rule='is above',        # Rule
                       metric='loss',          # Metric
@@ -96,7 +96,7 @@ if __name__ == "__main__":
             ...
 
         # Upload an output file
-        run.save('output.cdf', 'output')
+        run.save_file('output.cdf', 'output')
 
         # If we weren't using a context manager we'd need to end the run
         # run.close()

--- a/examples/GeometryOptimisation/bluemira_simvue_geometry_optimisation.py
+++ b/examples/GeometryOptimisation/bluemira_simvue_geometry_optimisation.py
@@ -171,5 +171,5 @@ my_problem.optimise()
 
 # Here we're minimising the length, within the bounds of our PrincetonD parameterisation,
 # so we'd expect that x1 goes to its upper bound, and x2 goes to its lower bound.
-run.save("bluemira_simvue_geometry_optimisation.py", "code")
+run.save_file("bluemira_simvue_geometry_optimisation.py", "code")
 run.close()

--- a/examples/PyTorch/main.py
+++ b/examples/PyTorch/main.py
@@ -205,7 +205,7 @@ def main():
         scheduler.step()
 
     if args.save_model:
-        run.save(model.state_dict(), "output", name="mnist_cnn.pt")
+        run.save_file(model.state_dict(), "output", name="mnist_cnn.pt")
 
     run.close()
 

--- a/examples/SU2/SU2.py
+++ b/examples/SU2/SU2.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
         filetype = None
         if input_file.endswith(".cfg"):
             filetype = "text/plain"
-        run.save(input_file, "input", filetype)
+        run.save_file(input_file, "input", filetype)
 
     running = True
     latest = []
@@ -106,6 +106,6 @@ if __name__ == "__main__":
 
     # Save output files
     for output_file in OUTPUT_FILES:
-        run.save(output_file, "output")
+        run.save_file(output_file, "output")
 
     run.close()

--- a/examples/Tensorflow/dynamic_rnn.py
+++ b/examples/Tensorflow/dynamic_rnn.py
@@ -45,7 +45,7 @@ if __name__ == "__main__":
             "computation over sequences with variable length. This example is using a toy dataset to "
             "classify linear sequences. The generated sequences have variable length.",
         )
-        run.save("dynamic_rnn.py", "code")
+        run.save_file("dynamic_rnn.py", "code")
 
         # ====================
         #  TOY DATA GENERATOR

--- a/simvue/client.py
+++ b/simvue/client.py
@@ -19,7 +19,7 @@ from .converters import (
     to_dataframe,
     parse_run_set_metrics,
 )
-from .serialization import Deserializer
+from .serialization import deserialize_data
 from .types import DeserializedContent
 from .utilities import check_extra, get_auth
 
@@ -608,7 +608,7 @@ class Client:
         response = requests.get(url, timeout=DOWNLOAD_TIMEOUT)
         response.raise_for_status()
 
-        content: typing.Optional[DeserializedContent] = Deserializer().deserialize(
+        content: typing.Optional[DeserializedContent] = deserialize_data(
             response.content, mimetype, allow_pickle
         )
 

--- a/simvue/executor.py
+++ b/simvue/executor.py
@@ -167,10 +167,10 @@ class Executor:
             )
 
         if script:
-            self._runner.save_file(filename=script, category="code")
+            self._runner.save_file(file_path=script, category="code")
 
         if input_file:
-            self._runner.save_file(filename=input_file, category="input")
+            self._runner.save_file(file_path=input_file, category="input")
 
         _command: typing.List[str] = []
 

--- a/simvue/executor.py
+++ b/simvue/executor.py
@@ -167,10 +167,10 @@ class Executor:
             )
 
         if script:
-            self._runner.save(filename=script, category="code")
+            self._runner.save_file(filename=script, category="code")
 
         if input_file:
-            self._runner.save(filename=input_file, category="input")
+            self._runner.save_file(filename=input_file, category="input")
 
         _command: typing.List[str] = []
 
@@ -284,11 +284,11 @@ class Executor:
         for proc_id in self._exit_codes.keys():
             # Only save the file if the contents are not empty
             if self._std_err[proc_id]:
-                self._runner.save(
+                self._runner.save_file(
                     f"{self._runner.name}_{proc_id}.err", category="output"
                 )
             if self._std_out[proc_id]:
-                self._runner.save(
+                self._runner.save_file(
                     f"{self._runner.name}_{proc_id}.out", category="output"
                 )
 

--- a/simvue/run.py
+++ b/simvue/run.py
@@ -1142,7 +1142,7 @@ class Run:
 
         for item in items:
             if item.is_file():
-                save_file = self.save(f"{item}", category, filetype, preserve_path)
+                save_file = self.save_file(item, category, filetype, preserve_path)
             elif item.is_dir():
                 save_file = self.save_directory(item, category, filetype, preserve_path)
             else:

--- a/simvue/serialization.py
+++ b/simvue/serialization.py
@@ -98,7 +98,7 @@ def _serialize_plotly_figure(data: typing.Any) -> typing.Optional[tuple[str, str
     except ImportError:
         return None
     mimetype = "application/vnd.plotly.v1+json"
-    data = plotly.io.to_json(data, "json")
+    data = plotly.io.to_json(data, engine="json")
     return data, mimetype
 
 
@@ -109,7 +109,7 @@ def _serialize_matplotlib(data: typing.Any) -> typing.Optional[tuple[str, str]]:
     except ImportError:
         return None
     mimetype = "application/vnd.plotly.v1+json"
-    data = plotly.io.to_json(plotly.tools.mpl_to_plotly(data.gcf()), "json")
+    data = plotly.io.to_json(plotly.tools.mpl_to_plotly(data.gcf()), engine="json")
     return data, mimetype
 
 
@@ -120,7 +120,7 @@ def _serialize_matplotlib_figure(data: typing.Any) -> typing.Optional[tuple[str,
     except ImportError:
         return None
     mimetype = "application/vnd.plotly.v1+json"
-    data = plotly.io.to_json(plotly.tools.mpl_to_plotly(data), "json")
+    data = plotly.io.to_json(plotly.tools.mpl_to_plotly(data), engine="json")
     return data, mimetype
 
 

--- a/simvue/serialization.py
+++ b/simvue/serialization.py
@@ -8,6 +8,7 @@ Contains serializers for storage of objects on the Simvue server
 import typing
 import pickle
 import pandas
+import json
 import numpy
 
 from io import BytesIO
@@ -82,6 +83,8 @@ def serialize_object(
                 return _serialize_matplotlib(data)
         except ImportError:
             pass
+    elif serialized := _serialize_json(data):
+        return serialized
 
     if allow_pickle:
         return _serialize_pickle(data)
@@ -152,6 +155,15 @@ def _serialize_torch_tensor(data: typing.Any) -> typing.Optional[tuple[str, str]
     torch.save(data, mfile)
     mfile.seek(0)
     data = mfile.read()
+    return data, mimetype
+
+
+def _serialize_json(data: typing.Any) -> typing.Optional[tuple[str, str]]:
+    mimetype = "application/json"
+    try:
+        data = json.dumps(data)
+    except TypeError:
+        return None
     return data, mimetype
 
 

--- a/simvue/serialization.py
+++ b/simvue/serialization.py
@@ -189,6 +189,8 @@ def deserialize_data(
         return _deserialize_dataframe(data)
     elif mimetype == "application/vnd.simvue.torch.v1":
         return _deserialize_torch_tensor(data)
+    elif mimetype == "application/json":
+        return _deserialize_json(data)
     elif mimetype == "application/octet-stream" and allow_pickle:
         return _deserialize_pickle(data)
     return None
@@ -240,6 +242,11 @@ def _deserialize_torch_tensor(data: "Buffer") -> typing.Optional["Tensor"]:
     return torch.load(mfile)
 
 
-def _deserialize_pickle(data):
+def _deserialize_pickle(data) -> typing.Optional[typing.Any]:
     data = pickle.loads(data)
+    return data
+
+
+def _deserialize_json(data) -> typing.Optional[typing.Any]:
+    data = json.loads(data)
     return data

--- a/simvue/serialization.py
+++ b/simvue/serialization.py
@@ -60,7 +60,7 @@ def serialize_object(
     Returns
     -------
     Callable[[typing.Any], tuple[str, str]]
-        the serializer to user
+        the serializer to use
     """
     module_name = data.__class__.__module__
     class_name = data.__class__.__name__

--- a/tests/functional/common.py
+++ b/tests/functional/common.py
@@ -1,4 +1,5 @@
 import configparser
+import pathlib
 import os
 import uuid
 
@@ -20,9 +21,9 @@ def update_config():
         config.write(configfile)
 
 FOLDER = '/test-%s' % str(uuid.uuid4())
-FILENAME1 = str(uuid.uuid4())
-FILENAME2 = str(uuid.uuid4())
-FILENAME3 = str(uuid.uuid4())
+FILENAME1 = pathlib.Path(str(uuid.uuid4()))
+FILENAME2 = pathlib.Path(str(uuid.uuid4()))
+FILENAME3 = pathlib.Path(str(uuid.uuid4()))
 RUNNAME1 = 'test-%s' % str(uuid.uuid4())
 RUNNAME2 = 'test-%s' % str(uuid.uuid4())
 RUNNAME3 = 'test-%s' % str(uuid.uuid4())

--- a/tests/functional/test_artifacts_code.py
+++ b/tests/functional/test_artifacts_code.py
@@ -1,12 +1,9 @@
-import configparser
 import filecmp
 import os
 import shutil
-import time
 import unittest
 import uuid
 from simvue import Run, Client
-from simvue.sender import sender
 
 import common
 
@@ -22,7 +19,7 @@ class TestArtifacts(unittest.TestCase):
         content = str(uuid.uuid4())
         with open(common.FILENAME1, 'w') as fh:
             fh.write(content)
-        run.save(common.FILENAME1, 'code')
+        run.save_file(common.FILENAME1, 'code')
 
         run.close()
 

--- a/tests/functional/test_artifacts_code_created.py
+++ b/tests/functional/test_artifacts_code_created.py
@@ -23,7 +23,7 @@ class TestArtifactsCreatedState(unittest.TestCase):
         content = str(uuid.uuid4())
         with open(common.FILENAME1, 'w') as fh:
             fh.write(content)
-        run.save(common.FILENAME1, 'code')
+        run.save_file(common.FILENAME1, 'code')
 
         shutil.rmtree('./test', ignore_errors=True)
         os.mkdir('./test')

--- a/tests/functional/test_artifacts_input.py
+++ b/tests/functional/test_artifacts_input.py
@@ -22,7 +22,7 @@ class TestArtifacts(unittest.TestCase):
         content = str(uuid.uuid4())
         with open(common.FILENAME2, 'w') as fh:
             fh.write(content)
-        run.save(common.FILENAME2, 'input')
+        run.save_file(common.FILENAME2, 'input')
 
         run.close()
 

--- a/tests/functional/test_artifacts_input_created.py
+++ b/tests/functional/test_artifacts_input_created.py
@@ -23,7 +23,7 @@ class TestArtifactsCreated(unittest.TestCase):
         content = str(uuid.uuid4())
         with open(common.FILENAME2, 'w') as fh:
             fh.write(content)
-        run.save(common.FILENAME2, 'input')
+        run.save_file(common.FILENAME2, 'input')
 
         shutil.rmtree('./test', ignore_errors=True)
         os.mkdir('./test')

--- a/tests/functional/test_artifacts_output.py
+++ b/tests/functional/test_artifacts_output.py
@@ -22,7 +22,7 @@ class TestArtifacts(unittest.TestCase):
         content = str(uuid.uuid4())
         with open(common.FILENAME3, 'w') as fh:
             fh.write(content)
-        run.save(common.FILENAME3, 'output')
+        run.save_file(common.FILENAME3, 'output')
 
         run.close()
 

--- a/tests/functional/test_artifacts_output_created.py
+++ b/tests/functional/test_artifacts_output_created.py
@@ -24,7 +24,7 @@ class TestArtifactsOutputCreated(unittest.TestCase):
             fh.write(content)
 
         with self.assertRaises(Exception) as context:
-            run.save(common.FILENAME3, 'output')
+            run.save_file(common.FILENAME3, 'output')
 
         self.assertTrue('Cannot upload output files for runs in the created state' in str(context.exception))
 

--- a/tests/functional/test_offline_artifacts_code.py
+++ b/tests/functional/test_offline_artifacts_code.py
@@ -29,7 +29,7 @@ class TestArtifactsOffline(unittest.TestCase):
         content = str(uuid.uuid4())
         with open(common.FILENAME1, 'w') as fh:
             fh.write(content)
-        run.save(common.FILENAME1, 'code')
+        run.save_file(common.FILENAME1, 'code')
 
         run.close()
 

--- a/tests/functional/test_offline_artifacts_code_created.py
+++ b/tests/functional/test_offline_artifacts_code_created.py
@@ -30,7 +30,7 @@ class TestArtifactsOffline(unittest.TestCase):
         content = str(uuid.uuid4())
         with open(common.FILENAME1, "w") as fh:
             fh.write(content)
-        run.save(common.FILENAME1, "code")
+        run.save_file(common.FILENAME1, "code")
 
         sender()
 

--- a/tests/functional/test_offline_artifacts_input.py
+++ b/tests/functional/test_offline_artifacts_input.py
@@ -30,7 +30,7 @@ class TestArtifactsOffline(unittest.TestCase):
         content = str(uuid.uuid4())
         with open(common.FILENAME2, "w") as fh:
             fh.write(content)
-        run.save(common.FILENAME2, "input")
+        run.save_file(common.FILENAME2, "input")
 
         run.close()
 

--- a/tests/functional/test_offline_artifacts_input_created.py
+++ b/tests/functional/test_offline_artifacts_input_created.py
@@ -30,7 +30,7 @@ class TestArtifactsOffline(unittest.TestCase):
         content = str(uuid.uuid4())
         with open(common.FILENAME2, "w") as fh:
             fh.write(content)
-        run.save(common.FILENAME2, "input")
+        run.save_file(common.FILENAME2, "input")
 
         sender()
 

--- a/tests/functional/test_offline_artifacts_output.py
+++ b/tests/functional/test_offline_artifacts_output.py
@@ -30,7 +30,7 @@ class TestArtifactsOffline(unittest.TestCase):
         content = str(uuid.uuid4())
         with open(common.FILENAME3, "w") as fh:
             fh.write(content)
-        run.save(common.FILENAME3, "output")
+        run.save_file(common.FILENAME3, "output")
 
         run.close()
 

--- a/tests/refactor/conftest.py
+++ b/tests/refactor/conftest.py
@@ -114,19 +114,19 @@ def setup_test_run(run: sv_run.Run, create_objects: bool):
         with tempfile.TemporaryDirectory() as tempd:
             with open((test_file := os.path.join(tempd, "test_file.txt")), "w") as out_f:
                 out_f.write("This is a test file")
-            run.save(test_file, category="input", name="test_file")
+            run.save_file(test_file, category="input", name="test_file")
             TEST_DATA["file_1"] = "test_file"
 
             with open((test_json := os.path.join(tempd, f"test_attrs_{fix_use_id}.json")), "w") as out_f:
                 json.dump(TEST_DATA, out_f, indent=2)
-            run.save(test_json, category="output", name="test_attributes")
+            run.save_file(test_json, category="output", name="test_attributes")
             TEST_DATA["file_2"] = "test_attributes"
 
-            with open((test_script := os.path.join(tempd, f"test_script.py")), "w") as out_f:
+            with open((test_script := os.path.join(tempd, "test_script.py")), "w") as out_f:
                 out_f.write(
                     "print('Hello World!')"
                 )
-            run.save(test_script, category="code", name="test_empty_file")
+            run.save_file(test_script, category="code", name="test_empty_file")
             TEST_DATA["file_3"] = "test_empty_file"
 
     time.sleep(1.)

--- a/tests/refactor/conftest.py
+++ b/tests/refactor/conftest.py
@@ -79,7 +79,7 @@ def setup_test_run(run: sv_run.Run, create_objects: bool, request: pytest.Fixtur
             "test_identifier": fix_use_id
         },
         "folder": f"/simvue_unit_testing/{fix_use_id}",
-        "tags": ["simvue_client_unit_tests", request.node.name]
+        "tags": ["simvue_client_unit_tests", request.node.name.replace("[", "_").replace("]", "_")]
     }
 
     if os.environ.get("CI"):

--- a/tests/refactor/test_run_class.py
+++ b/tests/refactor/test_run_class.py
@@ -377,3 +377,23 @@ def test_save_file(
                 assert variable.out == "WARNING: saving zero-sized files not currently supported\n"
 
 
+@pytest.mark.run
+@pytest.mark.parametrize("object_type", ("DataFrame", "ndarray"))
+def test_save_object(
+    create_plain_run: typing.Tuple[sv_run.Run, dict], object_type: str
+) -> None:
+    simvue_run, _ = create_plain_run
+
+    if object_type == "DataFrame":
+        try:
+            from pandas import DataFrame
+        except ImportError:
+            pytest.skip("Pandas is not installed")
+        save_obj = DataFrame({"x": [1, 2, 3, 4], "y": [2, 4, 6, 8]})
+    elif object_type == "ndarray":
+        try:
+            from numpy import array
+        except ImportError:
+            pytest.skip("Numpy is not installed")
+        save_obj = array([1, 2, 3, 4])
+    simvue_run.save_object(save_obj, "input", f"test_object_{object_type}")

--- a/tests/unit/test_matplotlib_figure_mime_type.py
+++ b/tests/unit/test_matplotlib_figure_mime_type.py
@@ -1,4 +1,4 @@
-from simvue.serialization import Serializer, Deserializer
+from simvue.serialization import serialize_object
 import matplotlib.pyplot as plt
 
 def test_matplotlib_figure_mime_type():
@@ -8,6 +8,6 @@ def test_matplotlib_figure_mime_type():
     plt.plot([1, 2, 3, 4])
     figure = plt.gcf()
 
-    _, mime_type = Serializer().serialize(figure)
+    _, mime_type = serialize_object(figure, False)
 
     assert (mime_type == 'application/vnd.plotly.v1+json')

--- a/tests/unit/test_numpy_array_mime_type.py
+++ b/tests/unit/test_numpy_array_mime_type.py
@@ -1,4 +1,4 @@
-from simvue.serialization import Serializer, Deserializer
+from simvue.serialization import serialize_object
 import numpy as np
 
 def test_numpy_array_mime_type():
@@ -6,6 +6,6 @@ def test_numpy_array_mime_type():
     Check that the mimetype for numpy arrays is correct
     """
     array = np.array([1, 2, 3, 4, 5])
-    _, mime_type = Serializer().serialize(array)
+    _, mime_type = serialize_object(array, False)
 
     assert (mime_type == 'application/vnd.simvue.numpy.v1')

--- a/tests/unit/test_numpy_array_serialization.py
+++ b/tests/unit/test_numpy_array_serialization.py
@@ -1,4 +1,4 @@
-from simvue.serialization import Serializer, Deserializer
+from simvue.serialization import serialize_object, deserialize_data
 import numpy as np
 
 def test_numpy_array_serialization():
@@ -7,7 +7,7 @@ def test_numpy_array_serialization():
     """
     array = np.array([1, 2, 3, 4, 5])
 
-    serialized, mime_type = Serializer().serialize(array)
-    array_out = Deserializer().deserialize(serialized, mime_type)
+    serialized, mime_type = serialize_object(array, False)
+    array_out = deserialize_data(serialized, mime_type, False)
 
     assert (array == array_out).all()

--- a/tests/unit/test_pandas_dataframe_mimetype.py
+++ b/tests/unit/test_pandas_dataframe_mimetype.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from simvue.serialization import Serializer, Deserializer
+from simvue.serialization import serialize_object
 
 def test_pandas_dataframe_mimetype():
     """
@@ -8,6 +8,6 @@ def test_pandas_dataframe_mimetype():
     data = {'col1': [1, 2], 'col2': [3, 4]}
     df = pd.DataFrame(data=data)
 
-    _, mime_type = Serializer().serialize(df)
+    _, mime_type = serialize_object(df, False)
 
     assert (mime_type == 'application/vnd.simvue.df.v1')

--- a/tests/unit/test_pandas_dataframe_serialization.py
+++ b/tests/unit/test_pandas_dataframe_serialization.py
@@ -1,4 +1,4 @@
-from simvue.serialization import Serializer, Deserializer
+from simvue.serialization import serialize_object, deserialize_data
 import pandas as pd
 
 def test_pandas_dataframe_serialization():
@@ -8,7 +8,7 @@ def test_pandas_dataframe_serialization():
     data = {'col1': [1, 2], 'col2': [3, 4]}
     df = pd.DataFrame(data=data)
 
-    serialized, mime_type = Serializer().serialize(df)
-    df_out = Deserializer().deserialize(serialized, mime_type)
+    serialized, mime_type = serialize_object(df, False)
+    df_out = deserialize_data(serialized, mime_type, False)
 
     assert (df.equals(df_out))

--- a/tests/unit/test_pickle_serialization.py
+++ b/tests/unit/test_pickle_serialization.py
@@ -1,5 +1,4 @@
-import pandas as pd
-from simvue.serialization import Serializer, Deserializer
+from simvue.serialization import deserialize_data, serialize_object
 
 def test_pickle_serialization():
     """
@@ -7,7 +6,7 @@ def test_pickle_serialization():
     """
     data = {'a': 1.0, 'b': 'test'}
 
-    serialized, mime_type = Serializer().serialize(data, allow_pickle=True)
-    data_out = Deserializer().deserialize(serialized, mime_type, allow_pickle=True)
+    serialized, mime_type = serialize_object(data, allow_pickle=True)
+    data_out = deserialize_data(serialized, mime_type, allow_pickle=True)
 
     assert (data == data_out)

--- a/tests/unit/test_plotly_figure_mime_type.py
+++ b/tests/unit/test_plotly_figure_mime_type.py
@@ -1,4 +1,4 @@
-from simvue.serialization import Serializer, Deserializer
+from simvue.serialization import serialize_object
 import matplotlib.pyplot as plt
 import plotly
 
@@ -10,6 +10,6 @@ def test_plotly_figure_mime_type():
     figure = plt.gcf()
     plotly_figure = plotly.tools.mpl_to_plotly(figure)
 
-    _, mime_type = Serializer().serialize(plotly_figure)
+    _, mime_type = serialize_object(plotly_figure, False)
 
     assert (mime_type == 'application/vnd.plotly.v1+json')

--- a/tests/unit/test_plotly_figure_mime_type.py
+++ b/tests/unit/test_plotly_figure_mime_type.py
@@ -3,8 +3,6 @@ import matplotlib.pyplot as plt
 import plotly
 import pytest
 
-from simvue.serialization import Serializer, Deserializer
-
 try:
     import matplotlib.pyplot as plt
 except ImportError:

--- a/tests/unit/test_pytorch_tensor_mime_type.py
+++ b/tests/unit/test_pytorch_tensor_mime_type.py
@@ -1,4 +1,4 @@
-from simvue.serialization import Serializer, Deserializer
+from simvue.serialization import serialize_object
 import torch
 
 def test_pytorch_tensor_mime_type():
@@ -7,6 +7,6 @@ def test_pytorch_tensor_mime_type():
     """
     torch.manual_seed(1724)
     array = torch.rand(2, 3)
-    _, mime_type = Serializer().serialize(array)
+    _, mime_type = serialize_object(array, False)
 
     assert (mime_type == 'application/vnd.simvue.torch.v1')

--- a/tests/unit/test_pytorch_tensor_mime_type.py
+++ b/tests/unit/test_pytorch_tensor_mime_type.py
@@ -1,10 +1,7 @@
-<<<<<<< HEAD
 from simvue.serialization import serialize_object
 import torch
-=======
 import pytest
-from simvue.serialization import Serializer, Deserializer
->>>>>>> dev
+
 
 try:
     import torch

--- a/tests/unit/test_pytorch_tensor_serialization.py
+++ b/tests/unit/test_pytorch_tensor_serialization.py
@@ -1,5 +1,5 @@
 import torch
-from simvue.serialization import Serializer, Deserializer
+from simvue.serialization import serialize_object, deserialize_data
 
 def test_pytorch_tensor_serialization():
     """
@@ -8,7 +8,7 @@ def test_pytorch_tensor_serialization():
     torch.manual_seed(1724)
     array = torch.rand(2, 3)
 
-    serialized, mime_type = Serializer().serialize(array)
-    array_out = Deserializer().deserialize(serialized, mime_type)
+    serialized, mime_type = serialize_object(array, False)
+    array_out = deserialize_data(serialized, mime_type, False)
 
     assert (array == array_out).all()

--- a/tests/unit/test_run_init_folder.py
+++ b/tests/unit/test_run_init_folder.py
@@ -1,4 +1,3 @@
-import os
 from simvue import Run
 import pytest
 

--- a/tests/unit/test_run_init_metadata.py
+++ b/tests/unit/test_run_init_metadata.py
@@ -1,4 +1,3 @@
-import os
 from simvue import Run
 import pytest
 

--- a/tests/unit/test_run_init_tags.py
+++ b/tests/unit/test_run_init_tags.py
@@ -1,4 +1,3 @@
-import os
 from simvue import Run
 import pytest
 


### PR DESCRIPTION
Refactors the serialization process, fixes a bug with a misused tuple and also adds additional tests.

Adds preference to serialize with JSON before pickling.

NOTE: This is a major alteration replacing `save` with `save_file` and `save_object` methods to `Run`.