### PR TITLE
Add default if 'user' cannot be retrieved for dirty commit

### DIFF
--- a/.github/workflows/test_client_macos.yml
+++ b/.github/workflows/test_client_macos.yml
@@ -28,4 +28,4 @@ jobs:
         export SIMVUE_URL=${{ secrets.SIMVUE_URL }}
         export SIMVUE_TOKEN=${{ secrets.SIMVUE_TOKEN }}
         poetry install --all-extras
-        poetry run pytest tests/unit/ tests/refactor/
+        poetry run pytest tests/unit/ tests/refactor/ -m 'not scenario'

--- a/.github/workflows/test_client_ubuntu.yml
+++ b/.github/workflows/test_client_ubuntu.yml
@@ -30,7 +30,7 @@ jobs:
         export SIMVUE_URL=${{ secrets.SIMVUE_URL }}
         export SIMVUE_TOKEN=${{ secrets.SIMVUE_TOKEN }}
         poetry install --all-extras
-        poetry run pytest --cov --cov-report=xml tests/unit/ tests/refactor/
+        poetry run pytest --cov --cov-report=xml tests/unit/ tests/refactor/ -m 'not scenario'
     - name: Upload coverage reports to Codecov
       run: |
         curl -Os https://uploader.codecov.io/latest/linux/codecov

--- a/.github/workflows/test_client_windows.yml
+++ b/.github/workflows/test_client_windows.yml
@@ -29,4 +29,4 @@ jobs:
         export SIMVUE_URL=${{ secrets.SIMVUE_URL }}
         export SIMVUE_TOKEN=${{ secrets.SIMVUE_TOKEN }}
         poetry install --all-extras
-        poetry run pytest tests/unit/ tests/refactor/
+        poetry run pytest tests/unit/ tests/refactor/ -m 'not scenario'

--- a/.github/workflows/test_multiple_python.yml
+++ b/.github/workflows/test_multiple_python.yml
@@ -32,4 +32,4 @@ jobs:
         export SIMVUE_URL=${{ secrets.SIMVUE_URL }}
         export SIMVUE_TOKEN=${{ secrets.SIMVUE_TOKEN }}
         poetry install --all-extras
-        poetry run pytest --cov --cov-report=xml tests/unit/ tests/refactor/
+        poetry run pytest tests/unit/ tests/refactor/ -m 'not scenario'

--- a/simvue/metadata.py
+++ b/simvue/metadata.py
@@ -45,7 +45,7 @@ def git_info(repository: str) -> dict[str, typing.Any]:
     # In the case where the repository is dirty blame should point to the
     # current developer, not the person responsible for the latest commit
     if dirty := git_repo.is_dirty():
-        blame = git_repo.config_reader().get_value("user", "email")
+        blame = git_repo.config_reader().get_value("user", "email", "unknown")
     else:
         blame = current_commit.committer.email
 


### PR DESCRIPTION
An issue on the Windows CI is that for some reason the repository is in a "dirty" state and the Git module cannot retrieve the user for the changes. This fix adds a default "unknown" for the case where the key cannot be found.