### PR TITLE
Fix consistency of folders tags for ci test runs

### DIFF
--- a/tests/functional/test_run_offline_folder.py
+++ b/tests/functional/test_run_offline_folder.py
@@ -24,7 +24,7 @@ class TestRunOfflineFolder(unittest.TestCase):
             pass
 
         name = "test-%s" % str(uuid.uuid4())
-        folder = "/test-%s" % str(uuid.uuid4())
+        folder = "/simvue_unit_testing"
         metadata = {str(uuid.uuid4()): 100 * random.random()}
         run = Run("offline")
         run.init(name, folder=folder)

--- a/tests/refactor/test_client.py
+++ b/tests/refactor/test_client.py
@@ -175,7 +175,6 @@ def test_run_deletion(create_test_run: tuple[sv_run.Run, dict]) -> None:
 @pytest.mark.client(depends=PRE_DELETION_TESTS)
 def test_runs_deletion(create_test_run: tuple[sv_run.Run, dict]) -> None:
     run, run_data = create_test_run
-    run.update_tags(["simvue_client_unit_tests", "test_runs_deletion"])
     run.close()
     client = svc.Client()
     assert len(client.delete_runs(run_data["folder"])) > 0
@@ -185,7 +184,6 @@ def test_runs_deletion(create_test_run: tuple[sv_run.Run, dict]) -> None:
 @pytest.mark.client(depends=PRE_DELETION_TESTS + ["test_runs_deletion"])
 def test_folder_deletion(create_test_run: tuple[sv_run.Run, dict]) -> None:
     run, run_data = create_test_run
-    run.update_tags(["simvue_client_unit_tests", "test_folder_deletion"])
     run.close()
     client = svc.Client()
     # This test is called last, one run created so expect length 1

--- a/tests/refactor/test_executor.py
+++ b/tests/refactor/test_executor.py
@@ -8,13 +8,14 @@ import multiprocessing
 @pytest.mark.executor
 @pytest.mark.parametrize("successful", (True, False), ids=("successful", "failing"))
 def test_executor_add_process(
-    successful: bool
+    successful: bool,
+    request: pytest.FixtureRequest
 ) -> None:
     run = simvue.Run()
     completion_trigger = multiprocessing.Event()
     run.init(
         f"test_executor_{'success' if successful else 'fail'}",
-        tags=["simvue_client_unit_tests"],
+        tags=["simvue_client_unit_tests", request.node.name],
         folder="/simvue_unit_test_folder"
     )
 

--- a/tests/unit/test_run_init_folder.py
+++ b/tests/unit/test_run_init_folder.py
@@ -15,7 +15,7 @@ def test_run_init_folder():
     with pytest.raises(RuntimeError) as exc_info:
         run.init(
             metadata={"dataset.x1_lower": x1_lower, "dataset.x1_upper": x1_upper},
-            tags=["tag_1", "tag_2"],
+            tags=["tag_1", "tag_2", "test_run_init_folder"],
             folder="test_folder",
             description="A test to validate folder input passed into run.init",
             retention_period="1 hour",

--- a/tests/unit/test_run_init_metadata.py
+++ b/tests/unit/test_run_init_metadata.py
@@ -15,7 +15,9 @@ def test_run_init_metadata():
     with pytest.raises(RuntimeError) as exc_info:
         run.init(metadata={'dataset.x1_lower': x1_lower, 'dataset.x1_upper': x1_upper},
                 description="A test to validate inputs passed into metadata dictionary",
-                retention_period="1 hour"
+                retention_period="1 hour",
+                folder="/simvue_unit_testing",
+                tags=["simvue_client_unit_tests", "test_run_init_metadata"]
         )
 
     assert "Input should be a valid integer" in str(exc_info.value)

--- a/tests/unit/test_run_init_tags.py
+++ b/tests/unit/test_run_init_tags.py
@@ -15,7 +15,8 @@ def test_run_init_tags():
     with pytest.raises(RuntimeError) as exc_info:
         run.init(metadata={'dataset.x1_lower': x1_lower, 'dataset.x1_upper': x1_upper}, tags=1,
                 description="A test to validate tag inputs passed into run.init",
-                retention_period="1 hour"
+                retention_period="1 hour",
+                folder="/simvue_unit_testing"
         )
 
     assert "Input should be a valid list" in str(exc_info.value)


### PR DESCRIPTION
Uses the pytest `request` fixture to add test name to tags, and adds `ci` tag if the `CI` environment variable is set.

closes #338