### PR TITLE
Use alerts for executor process reporting and stdout if stderr not available

### DIFF
--- a/simvue/run.py
+++ b/simvue/run.py
@@ -184,9 +184,13 @@ class Run:
             _error_msg = "\n".join(
                 f"{identifier}:\n{msg}" for identifier, msg in _error_msgs.items()
             )
-            logger.error(
+            if _error_msg:
+                _error_msg = f":\n{_error_msg}"
+            click.secho(
                 "Simvue process executor terminated with non-zero exit status "
-                f"{_non_zero}{(':\n' + _error_msg) if _error_msg else ''}"
+                f"{_non_zero}{_error_msg}",
+                fg="red",
+                bold=True,
             )
             sys.exit(_non_zero)
 
@@ -1388,9 +1392,13 @@ class Run:
             _error_msg = "\n".join(
                 f"{identifier}:\n{msg}" for identifier, msg in _error_msgs.items()
             )
-            logger.error(
+            if _error_msg:
+                _error_msg = f":\n{_error_msg}"
+            click.secho(
                 "Simvue process executor terminated with non-zero exit status "
-                f"{_non_zero}{(':\n' + _error_msg) if _error_msg else ''}"
+                f"{_non_zero}{_error_msg}",
+                fg="red",
+                bold=True,
             )
             sys.exit(_non_zero)
 

--- a/simvue/run.py
+++ b/simvue/run.py
@@ -178,8 +178,15 @@ class Run:
                 self._dispatcher.join()
 
         if _non_zero := self.executor.exit_status:
+            _error_msgs: dict[str, typing.Optional[str]] = (
+                self.executor.get_error_summary()
+            )
+            _error_msg = "\n".join(
+                f"{identifier}:\n{msg}" for identifier, msg in _error_msgs.items()
+            )
             logger.error(
-                f"Simvue process executor terminated with non-zero exit status {_non_zero}"
+                "Simvue process executor terminated with non-zero exit status "
+                f"{_non_zero}{(':\n' + _error_msg) if _error_msg else ''}"
             )
             sys.exit(_non_zero)
 
@@ -1375,8 +1382,15 @@ class Run:
             self._dispatcher.join()
 
         if _non_zero := self.executor.exit_status:
+            _error_msgs: dict[str, typing.Optional[str]] = (
+                self.executor.get_error_summary()
+            )
+            _error_msg = "\n".join(
+                f"{identifier}:\n{msg}" for identifier, msg in _error_msgs.items()
+            )
             logger.error(
-                f"Simvue process executor terminated with non-zero exit status {_non_zero}"
+                "Simvue process executor terminated with non-zero exit status "
+                f"{_non_zero}{(':\n' + _error_msg) if _error_msg else ''}"
             )
             sys.exit(_non_zero)
 


### PR DESCRIPTION
This moves from using events to draw attention to failing processes added via the executor to instead using user alerts. Also in the case where `stderr` is empty, the last 10 lines of `stdout` are given in the logging output.

The user is still able to see info relating to the failing run as the uploaded `out` and `err` files.