### PR TITLE
Fix ambiguity issue with numpy artifact retrieval

### DIFF
--- a/simvue/client.py
+++ b/simvue/client.py
@@ -641,7 +641,9 @@ class Client:
             response.content, mimetype, allow_pickle
         )
 
-        return content or response.content
+        # Numpy array return means just 'if content' will be ambiguous
+        # so must explicitly check if None
+        return response.content if content is None else content
 
     @prettify_pydantic
     @pydantic.validate_call


### PR DESCRIPTION
When returning a numpy artifact the statement `return content or content.response` will throw an ambiguity error due to the assertion of a numpy array being ambiguous. This fix switches to checking explicitly for `None`.