### PR TITLE
[skip ci] Added T201 to Ruff (no print statements)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,8 +89,13 @@ priority = "primary"
 
 
 [tool.ruff]
-lint.extend-select = ["C901"]
+lint.extend-select = ["C901", "T201"]
 lint.mccabe.max-complexity = 11
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["T201"]
+"examples/*" = ["T201"]
+"notebooks/*" = ["T201"]
 
 [tool.pytest.ini_options]
 addopts = "-p no:warnings --cov=simvue -n auto"

--- a/simvue/factory/proxy/remote.py
+++ b/simvue/factory/proxy/remote.py
@@ -370,7 +370,6 @@ class Remote(SimvueBaseClass):
         if not (response_data := response.json()) or (
             (data := response_data.get("data")) is None
         ):
-            print(response_data)
             self._error(
                 "Expected key 'alerts' in response from server during alert retrieval"
             )

--- a/simvue/metadata.py
+++ b/simvue/metadata.py
@@ -65,10 +65,3 @@ def git_info(repository: str) -> dict[str, typing.Any]:
         "git.url": git_repo.remote().url,
         "git.dirty": dirty,
     }
-
-
-if __name__ in "__main__":
-    import os.path
-    import json
-
-    print(json.dumps(git_info(os.path.dirname(__file__)), indent=2))


### PR DESCRIPTION
Adds rule forbidding use of `print` in the code, all printouts should be either `click.echo` or `logger` statements.