### PR TITLE
Add auto-abort feature to client

### DIFF
--- a/simvue/api.py
+++ b/simvue/api.py
@@ -44,7 +44,7 @@ def set_json_header(headers: dict[str, str]) -> dict[str, str]:
     reraise=True,
 )
 def post(
-    url: str, headers: dict[str, str], data: dict[str, typing.Any], is_json: bool = True
+    url: str, headers: dict[str, str], data: typing.Any, is_json: bool = True
 ) -> requests.Response:
     """HTTP POST with retries
 

--- a/simvue/client.py
+++ b/simvue/client.py
@@ -605,6 +605,45 @@ class Client:
 
     @prettify_pydantic
     @pydantic.validate_call
+    def abort_run(self, run_id: str, reason: str) -> typing.Union[dict, list]:
+        """Abort a currently active run on the server
+
+        Parameters
+        ----------
+        run_id : str
+            the unique identifier for the run
+        reason : str
+            reason for abort
+
+        Returns
+        -------
+        dict | list
+            response from server
+        """
+        body: dict[str, str | None] = {"id": run_id, "reason": reason}
+
+        response = requests.put(
+            f"{self._url}/api/runs/abort",
+            headers=self._headers,
+            json=body,
+        )
+
+        json_response = self._get_json_from_response(
+            expected_status=[200, 400],
+            scenario=f"Abort of run '{run_id}'",
+            response=response,
+        )
+
+        if not isinstance(json_response, dict):
+            raise RuntimeError(
+                "Expected list from JSON response during retrieval of "
+                f"artifact but got '{type(json_response)}'"
+            )
+
+        return json_response
+
+    @prettify_pydantic
+    @pydantic.validate_call
     def get_artifact(
         self, run_id: str, name: str, allow_pickle: bool = False
     ) -> typing.Any:

--- a/simvue/executor.py
+++ b/simvue/executor.py
@@ -271,8 +271,8 @@ class Executor:
         err_msg: typing.Optional[str] = None
 
         # Return last 10 lines of stdout if stderr empty
-        if not (err_msg := self._std_err[process_id]) and (
-            std_out := self._std_out[process_id]
+        if not (err_msg := self._std_err.get(process_id)) and (
+            std_out := self._std_out.get(process_id)
         ):
             err_msg = "  Tail STDOUT:\n\n"
             start_index = -10 if len(lines := std_out.split("\n")) > 10 else 0
@@ -307,11 +307,11 @@ class Executor:
         """Save the output to Simvue"""
         for proc_id in self._exit_codes.keys():
             # Only save the file if the contents are not empty
-            if self._std_err[proc_id]:
+            if self._std_err.get(proc_id):
                 self._runner.save_file(
                     f"{self._runner.name}_{proc_id}.err", category="output"
                 )
-            if self._std_out[proc_id]:
+            if self._std_out.get(proc_id):
                 self._runner.save_file(
                     f"{self._runner.name}_{proc_id}.out", category="output"
                 )

--- a/simvue/executor.py
+++ b/simvue/executor.py
@@ -308,8 +308,12 @@ class Executor:
             logger.debug(f"Terminating child process {child.pid}: {child.name()}")
             child.kill()
 
+        for child in parent.children(recursive=True):
+            child.wait()
+
         logger.debug(f"Terminating child process {process.pid}: {process.args}")
-        process.terminate()
+        process.kill()
+        process.wait()
 
         self._execute_callback(process_id)
 

--- a/simvue/factory/proxy/base.py
+++ b/simvue/factory/proxy/base.py
@@ -89,3 +89,7 @@ class SimvueBaseClass(abc.ABC):
     @abc.abstractmethod
     def check_token(self) -> bool:
         pass
+
+    @abc.abstractmethod
+    def get_abort_status(self) -> bool:
+        pass

--- a/simvue/factory/proxy/offline.py
+++ b/simvue/factory/proxy/offline.py
@@ -171,9 +171,15 @@ class Offline(SimvueBaseClass):
 
     @skip_if_failed("_aborted", "_suppress_errors", [])
     def list_tags(self) -> list[dict[str, typing.Any]]:
+        #TODO: Tag retrieval not implemented for offline running
         raise NotImplementedError(
             "Retrieval of current tags is not implemented for offline running"
         )
+    
+    @skip_if_failed("_aborted", "_suppress_errors", True)
+    def get_abort_status(self) -> bool:
+        #TODO: Abort on failure not implemented for offline running
+        return True
 
     @skip_if_failed("_aborted", "_suppress_errors", [])
     def list_alerts(self) -> list[dict[str, typing.Any]]:

--- a/simvue/factory/proxy/remote.py
+++ b/simvue/factory/proxy/remote.py
@@ -467,3 +467,26 @@ class Remote(SimvueBaseClass):
             self._error("Token has expired")
             return False
         return True
+    
+    @skip_if_failed("_aborted", "_suppress_errors", False)
+    def get_abort_status(self) -> bool:
+        logger.debug("Retrieving alert status")
+
+        try:
+            response = get(
+                f"{self._url}/api/runs/{self._id}/abort", self._headers_mp
+            )
+        except Exception as err:
+            self._error(f"Exception retrieving abort status: {str(err)}")
+            return False
+
+        logger.debug("Got status code %d when checking abort status", response.status_code)
+
+        if response.status_code == 200:
+            if (status := response.json().get("status")) is None:
+                self._error(f"Expected key 'status' when retrieving abort status {response.json()}")
+                return False
+            return status
+
+        self._error(f"Got status code {response.status_code} when checking abort status")
+        return False

--- a/simvue/run.py
+++ b/simvue/run.py
@@ -189,7 +189,7 @@ class Run:
             if _error_msg:
                 _error_msg = f":\n{_error_msg}"
             click.secho(
-                "Simvue process executor terminated with non-zero exit status "
+                "[simvue] Process executor terminated with non-zero exit status "
                 f"{_non_zero}{_error_msg}",
                 fg="red",
                 bold=True,
@@ -294,7 +294,8 @@ class Run:
                             self._dispatcher.purge()
                             self._dispatcher.join()
                         self.set_status("terminated")
-                        raise RuntimeError("Run was aborted")
+                        click.secho("[simvue] Run was aborted.", fg="red", bold=True)
+                        os._exit(1)
 
                 if self._simvue:
                     self._simvue.send_heartbeat()
@@ -1232,7 +1233,7 @@ class Run:
 
         if not file_size:
             click.secho(
-                "WARNING: saving zero-sized files not currently supported",
+                "[simvue] WARNING: saving zero-sized files not currently supported",
                 bold=True,
                 fg="yellow",
             )
@@ -1420,7 +1421,7 @@ class Run:
             if _error_msg:
                 _error_msg = f":\n{_error_msg}"
             click.secho(
-                "Simvue process executor terminated with non-zero exit status "
+                "[simvue] Process executor terminated with non-zero exit status "
                 f"{_non_zero}{_error_msg}",
                 fg="red",
                 bold=True,

--- a/simvue/run.py
+++ b/simvue/run.py
@@ -298,7 +298,7 @@ class Run:
                         and self._alert_raised_trigger
                     ):
                         self._alert_raised_trigger.set()
-                        self.close(False)
+                        self._close_session(False)
                         break
 
                 if self._simvue:

--- a/simvue/run.py
+++ b/simvue/run.py
@@ -295,7 +295,11 @@ class Run:
                             self._dispatcher.purge()
                             self._dispatcher.join()
                         self.set_status("terminated")
-                        click.secho("[simvue] Run was aborted.", fg="red", bold=True)
+                        click.secho(
+                            "[simvue] Run was aborted.",
+                            fg="red" if self._term_color else None,
+                            bold=self._term_color,
+                        )
                         os._exit(1)
 
                 if self._simvue:

--- a/simvue/types.py
+++ b/simvue/types.py
@@ -5,6 +5,7 @@ try:
 except ImportError:
     from typing_extensions import TypeAlias
 
+
 if typing.TYPE_CHECKING:
     from numpy import ndarray
     from pandas import DataFrame

--- a/tests/refactor/test_run_class.py
+++ b/tests/refactor/test_run_class.py
@@ -464,22 +464,15 @@ def test_save_object(
 @pytest.mark.run
 def test_abort_on_alert(create_plain_run: typing.Tuple[sv_run.Run, dict]) -> None:
     run, _ = create_plain_run
-    run.create_alert(
+    alert_id = run.create_alert(
         "forever_fails",
-        source="metrics",
-        metric="x",
-        frequency=1,
-        window=1,
-        rule="is below",
-        threshold=0,
+        source="user"
     )
     run.config(resources_metrics_interval=1)
     run._heartbeat_interval = 1
     run.add_process(identifier="forever_long", executable="bash", c="sleep 10000")
     time.sleep(2)
-    run.log_metrics({"x": -1})
-    time.sleep(1)
-    run.log_metrics({"x": -1})
+    run.log_alert(alert_id, "critical")
     time.sleep(4)
     if not run._aborted:
         run.kill_all_processes()

--- a/tests/refactor/test_run_class.py
+++ b/tests/refactor/test_run_class.py
@@ -517,6 +517,15 @@ def test_abort_on_alert_python(create_plain_run: typing.Tuple[sv_run.Run, dict],
 def test_kill_all_processes(create_plain_run: typing.Tuple[sv_run.Run, dict]) -> None:
     run, _ = create_plain_run
     run.config(resources_metrics_interval=1)
-    run.add_process(identifier="forever_long", executable="bash", c="sleep 10000")
+    run.add_process(identifier="forever_long_1", executable="bash", c="sleep 10000")
+    run.add_process(identifier="forever_long_2", executable="bash", c="sleep 10000")
+    processes = [
+        psutil.Process(process.pid)
+        for process in run._executor._processes.values()
+    ]
     time.sleep(2)
     run.kill_all_processes()
+    time.sleep(4)
+    for process in processes:
+        assert not process.is_running()
+        assert all(not child.is_running() for child in process.children(recursive=True))

--- a/tests/refactor/test_run_class.py
+++ b/tests/refactor/test_run_class.py
@@ -461,7 +461,7 @@ def test_save_object(
 
 
 @pytest.mark.run
-def test_abort_on_alert(create_plain_run: typing.Tuple[sv_run.Run, dict]) -> None:
+def test_abort_on_alert_process(create_plain_run: typing.Tuple[sv_run.Run, dict]) -> None:
     run, _ = create_plain_run
     run.config(resources_metrics_interval=1)
     run._heartbeat_interval = 1
@@ -473,6 +473,26 @@ def test_abort_on_alert(create_plain_run: typing.Tuple[sv_run.Run, dict]) -> Non
     if not run._status == "terminated":
         run.kill_all_processes()
         raise AssertionError("Run was not terminated")
+    
+
+@pytest.mark.run
+def test_abort_on_alert_python(create_plain_run: typing.Tuple[sv_run.Run, dict]) -> None:
+    run, _ = create_plain_run
+    run.config(resources_metrics_interval=1)
+    run._heartbeat_interval = 1
+    client = sv_cl.Client()
+    i = 0
+
+    while True:
+        time.sleep(1)
+        if i == 4:
+            client.abort_run(run._id, reason="testing abort")
+        i += 1
+        if i == 10:
+            break
+
+    assert i == 4
+    assert run._status == "terminated"
 
 
 @pytest.mark.run

--- a/tests/refactor/test_run_class.py
+++ b/tests/refactor/test_run_class.py
@@ -459,3 +459,32 @@ def test_save_object(
             pytest.skip("Numpy is not installed")
         save_obj = array([1, 2, 3, 4])
     simvue_run.save_object(save_obj, "input", f"test_object_{object_type}")
+
+
+@pytest.mark.run
+def test_abort_on_fail(create_plain_run: typing.Tuple[sv_run.Run, dict]) -> None:
+    run, _ = create_plain_run
+    alert_id = run.create_alert("forever_fails", source="user")
+    run.config(resources_metrics_interval=1)
+    run._heartbeat_interval = 1
+    run.add_process(
+        identifier="forever_long",
+        executable="bash",
+        c="sleep 10000"
+    )
+    time.sleep(2)
+    run.log_alert(alert_id, "critical")
+    time.sleep(4)
+    
+
+@pytest.mark.run
+def test_kill_all_processes(create_plain_run: typing.Tuple[sv_run.Run, dict]) -> None:
+    run, _ = create_plain_run
+    run.config(resources_metrics_interval=1)
+    run.add_process(
+        identifier="forever_long",
+        executable="bash",
+        c="sleep 10000"
+    )
+    time.sleep(2)
+    run.kill_all_processes()


### PR DESCRIPTION
Adds the functionality allowing users to terminate runs either remotely via the website or using the `Client` class method `abort_run`.