### PR TITLE
[skip ci]Only run other python version checks on tagged release candidate

### DIFF
--- a/.github/workflows/test_multiple_python.yml
+++ b/.github/workflows/test_multiple_python.yml
@@ -5,9 +5,8 @@ name: Simvue Client (Python Versions)
 
 on:
   push:
-    branches: [ "main", "dev", "hotfix/update-ci" ]
-  pull_request:
-    branches: [ "main", "dev", "hotfix/update-ci" ]
+    tags:
+      - 'v*-*-rc*'
 
 permissions:
   contents: read


### PR DESCRIPTION
Removes running CI for other Python versions on all branches,instead this only occurs on tagged release candidates