### PR TITLE
Fix use of posix string instead of string in executor

### DIFF
--- a/simvue/executor.py
+++ b/simvue/executor.py
@@ -182,10 +182,10 @@ class Executor:
             _pos_args.pop(0)
 
         if script:
-            _command += [script]
+            _command += [f"{script}"]
 
         if input_file:
-            _command += [input_file]
+            _command += [f"{input_file}"]
 
         for arg, value in kwargs.items():
             if arg.startswith("__"):


### PR DESCRIPTION
Fixes a bug whereby a posix path is passed instead of a string in the executor