### PR TITLE
Fix tests with resource metrics interval and add manual CI trigger

### DIFF
--- a/.github/workflows/test_client_macos.yml
+++ b/.github/workflows/test_client_macos.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main", "dev", "hotfix/update-ci" ]
   pull_request:
     branches: [ "main", "dev", "hotfix/update-ci" ]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/test_client_ubuntu.yml
+++ b/.github/workflows/test_client_ubuntu.yml
@@ -8,6 +8,7 @@ on:
     branches: [ "main", "dev", "hotfix/update-ci" ]
   pull_request:
     branches: [ "main", "dev", "hotfix/update-ci" ]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/test_client_windows.yml
+++ b/.github/workflows/test_client_windows.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main", "dev", "hotfix/update-ci" ]
   pull_request:
     branches: [ "main", "dev", "hotfix/update-ci" ]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/test_multiple_python.yml
+++ b/.github/workflows/test_multiple_python.yml
@@ -7,6 +7,7 @@ on:
   push:
     tags:
       - 'v*-*-rc*'
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/tests/refactor/test_run_class.py
+++ b/tests/refactor/test_run_class.py
@@ -62,8 +62,8 @@ def test_log_metrics(
                 folder="/simvue_unit_testing",
                 retention_period="1 hour",
                 visibility=visibility,
-                resources_metrics_interval=1,
             )
+            run.config(resources_metrics_interval=1)
         return
 
     run.init(
@@ -74,9 +74,9 @@ def test_log_metrics(
         ],
         folder="/simvue_unit_testing",
         visibility=visibility,
-        resources_metrics_interval=1,
         retention_period="1 hour",
     )
+    run.config(resources_metrics_interval=1)
 
     # Speed up the read rate for this test
     run._dispatcher._max_buffer_size = 10


### PR DESCRIPTION
* Fixes tests which set `resources_metrics_interval` to use `config`.
* Adds manual CI trigger to workflows