### PR TITLE
Fix handling of killing a process that doesnt exist anymore

### DIFF
--- a/simvue/executor.py
+++ b/simvue/executor.py
@@ -335,9 +335,15 @@ class Executor:
                     f"Failed to terminate process '{process_id}', no such identifier."
                 )
                 return
-            parent = psutil.Process(process.pid)
+            try:
+                parent = psutil.Process(process.pid)
+            except psutil.NoSuchProcess:
+                return
         elif isinstance(process_id, int):
-            parent = psutil.Process(process_id)
+            try:
+                parent = psutil.Process(process_id)
+            except psutil.NoSuchProcess:
+                return
 
         for child in parent.children(recursive=True):
             logger.debug(f"Terminating child process {child.pid}: {child.name()}")


### PR DESCRIPTION
Fixes a bug where a process may be added to the kill list that no longer exists anyway. Uses `psutil.NoSuchProcess` handling.