### PR TITLE
Fix `abort=true` being set in wrong request

### DIFF
--- a/simvue/client.py
+++ b/simvue/client.py
@@ -546,11 +546,6 @@ class Client:
         ----------
         alert_id : str
             the unique identifier for the alert
-
-        Returns
-        -------
-        typing.Optional[str]
-            server response
         """
         response = requests.delete(
             f"{self._url}/api/alerts/{alert_id}", headers=self._headers

--- a/simvue/run.py
+++ b/simvue/run.py
@@ -1733,6 +1733,7 @@ class Run:
             "source": source,
             "alert": alert_definition,
             "description": description,
+            "abort": trigger_abort,
         }
 
         # Check if the alert already exists
@@ -1753,6 +1754,7 @@ class Run:
 
         if not alert_id:
             try:
+                logger.debug(f"Creating new alert with definition: {alert}")
                 response = self._simvue.add_alert(alert)
             except RuntimeError as e:
                 self._error(f"{e.args[0]}")
@@ -1766,7 +1768,8 @@ class Run:
 
         if alert_id:
             # TODO: What if we keep existing alerts/add a new one later?
-            data = {"id": self._id, "alerts": [alert_id], "abort": trigger_abort}
+            data = {"id": self._id, "alerts": [alert_id]}
+            logger.debug(f"Updating run with info: {data}")
 
             try:
                 self._simvue.update(data)

--- a/simvue/utilities.py
+++ b/simvue/utilities.py
@@ -332,9 +332,9 @@ def validate_timestamp(timestamp):
 
 def compare_alerts(first, second):
     """ """
-    for key in ("name", "description", "source", "frequency", "notification"):
+    for key in ("name", "description", "source", "frequency", "notification", "abort"):
         if key in first and key in second:
-            if not first[key]:
+            if first[key] is None:
                 continue
 
             if first[key] != second[key]:
@@ -343,7 +343,7 @@ def compare_alerts(first, second):
     if "alerts" in first and "alerts" in second:
         for key in ("rule", "window", "metric", "threshold", "range_low", "range_high"):
             if key in first["alerts"] and key in second["alerts"]:
-                if not first[key]:
+                if first[key] is None:
                     continue
 
                 if first["alerts"][key] != second["alerts"]["key"]:

--- a/tests/refactor/test_run_class.py
+++ b/tests/refactor/test_run_class.py
@@ -487,6 +487,23 @@ def test_abort_on_alert_process(create_plain_run: typing.Tuple[sv_run.Run, dict]
         run.kill_all_processes()
         raise AssertionError("Run was not terminated")
     
+@pytest.mark.run
+def test_abort_on_alert_raise(create_plain_run: typing.Tuple[sv_run.Run, dict], mocker: pytest_mock.MockerFixture) -> None:
+    def testing_exit(status: int) -> None:
+        raise SystemExit(status)
+    mocker.patch("os._exit", testing_exit)
+    run, _ = create_plain_run
+    run.config(resources_metrics_interval=1)
+    run._heartbeat_interval = 1
+    run._testing = True
+    alert_id = run.create_alert("abort_test", source="user", trigger_abort=True)
+    run.add_process(identifier="forever_long", executable="bash", c="sleep 10")
+    time.sleep(2)
+    run.log_alert(alert_id, "critical")
+    time.sleep(4)
+    if not run._status == "terminated":
+        run.kill_all_processes()
+        raise AssertionError("Run was not terminated")
 
 @pytest.mark.run
 def test_abort_on_alert_python(create_plain_run: typing.Tuple[sv_run.Run, dict], mocker: pytest_mock.MockerFixture) -> None:


### PR DESCRIPTION
Fixes bug where the `"abort": True` was being added to run updates and not alert creation. Also ensures comparison of alerts includes if the alert can abort.