### PR TITLE
Fix hanging on API call in Run

### DIFF
--- a/simvue/run.py
+++ b/simvue/run.py
@@ -377,9 +377,13 @@ class Run:
 
             _msgpack_header = headers | {"Content-Type": "application/msgpack"}
 
-            sv_api.post(
-                url=_url, headers=_msgpack_header, data=_data_bin, is_json=False
-            )
+            try:
+                sv_api.post(
+                    url=_url, headers=_msgpack_header, data=_data_bin, is_json=False
+                )
+            except (ValueError, RuntimeError) as e:
+                self._error(f"{e}")
+                return
 
         return (
             _online_dispatch_callback


### PR DESCRIPTION
Fix issue whereby if the `simvue.api.post` returns an exception `Run` hangs due to no thread termination.