### PR TITLE
Handle internal use case of set_status where run not initialised

### DIFF
--- a/simvue/run.py
+++ b/simvue/run.py
@@ -305,7 +305,8 @@ class Run:
                             self._shutdown_event.set()
                             self._dispatcher.purge()
                             self._dispatcher.join()
-                        self.set_status("terminated")
+                        if self._active:
+                            self.set_status("terminated")
                         click.secho(
                             "[simvue] Run was aborted.",
                             fg="red" if self._term_color else None,
@@ -1482,7 +1483,8 @@ class Run:
         if self._status == "running":
             if self._dispatcher:
                 self._dispatcher.join()
-            self.set_status("completed")
+            if self._active:
+                self.set_status("completed")
         elif self._dispatcher:
             self._dispatcher.purge()
             self._dispatcher.join()


### PR DESCRIPTION
Fixes issue caused by `self.set_status` being called during exception handling even when a run has not yet been initialised.

Closes #532 