### PR TITLE
🐛 Handle KeyError for object retrieval

### DIFF
--- a/simvue/api/objects/run.py
+++ b/simvue/api/objects/run.py
@@ -372,7 +372,7 @@ class Run(SimvueObject):
             raise RuntimeError(
                 "Cannot get alert details from an offline run - use .alerts to access a list of IDs instead"
             )
-        for alert in self._get_attribute("alerts", local_default=[]):
+        for alert in self._get_attribute("alerts"):
             yield alert["alert"]
 
     @property
@@ -457,7 +457,7 @@ class Run(SimvueObject):
         -------
         Generator[tuple[str, dict[str, int | float | bool]]
         """
-        yield from self._get_attribute("metrics", local_default={}).items()
+        yield from self._get_attribute("metrics").items()
 
     @property
     def events(


### PR DESCRIPTION
# Fix Slow Run Retrieval

**Issue:** https://github.com/simvue-io/python-api/issues/846

**Python Version(s) Tested:** 3.13

**Operating System(s):** Ubuntu 25.04

## 📝 Summary

The retrieval of `Run` objects is very slow for large quantities.

## 🔍 Diagnosis

- The pagination seems to be working.
- The default of `get_runs` has `alerts=False` but `alerts` is a property of the `Run` LLAPI class. The base class `__repr__` method iterates through all properties meaning because the `"alerts"` key was missing the automatic 'get from server' method was being called for each run.

## 🔄 Changes

- ~~I have removed this automatic retrieval, hopefully it does not break things.~~
- ~~Added `local_default` value to be used when object is in "local" mode.~~
- ~~"Local" mode used for `get` - bulk item retrieval.~~
- Object will not print elements it does not have retrieved, if the user attempts `Run(...).alerts` when they used `get_runs(alerts=False)` a `KeyError` will be returned.

## ✔️ Checklist
- [ ] Unit and integration tests passing.
- [x] Pre-commit hooks passing.
- [x] Quality checks passing.
