### PR TITLE
Update abort_on_alert

### DIFF
--- a/simvue/run.py
+++ b/simvue/run.py
@@ -23,7 +23,6 @@ import time
 import functools
 import platform
 import typing
-import warnings
 import uuid
 import numpy
 import randomname
@@ -1065,7 +1064,7 @@ class Run:
         enable_emission_metrics: bool | None = None,
         disable_resources_metrics: bool | None = None,
         storage_id: str | None = None,
-        abort_on_alert: typing.Literal["run", "all", "ignore"] | bool | None = None,
+        abort_on_alert: typing.Literal["run", "terminate", "ignore"] | None = None,
     ) -> bool:
         """Optional configuration
 
@@ -1084,10 +1083,10 @@ class Run:
             disable monitoring of resource metrics
         storage_id : str, optional
             identifier of storage to use, by default None
-        abort_on_alert : Literal['ignore', run', 'terminate'], optional
+        abort_on_alert : Literal['ignore', 'terminate', 'ignore'], optional
             whether to abort when an alert is triggered.
                 * run - current run is aborted.
-                * terminate - script itself is terminated.
+                * terminate - (default) script itself is terminated.
                 * ignore - alerts do not affect this run.
 
         Returns
@@ -1153,11 +1152,12 @@ class Run:
 
             if abort_on_alert is not None:
                 if isinstance(abort_on_alert, bool):
-                    warnings.warn(
-                        "Use of type bool for argument 'abort_on_alert' will be deprecated from v1.2, "
-                        "please use either 'run', 'all' or 'ignore'"
+                    raise (
+                        TypeError(
+                            "Use of type bool for argument 'abort_on_alert' has been removed, "
+                            "please use either 'run', 'all' or 'ignore'"
+                        )
                     )
-                    abort_on_alert = "run" if self._abort_on_alert else "ignore"
                 self._abort_on_alert = abort_on_alert
 
             if storage_id:


### PR DESCRIPTION
# Fix `alert_on_abort` behaviour and documentation

## 📝 Summary

The ability to pass a `bool` was deprecated back in version 1.2. The `| bool` in the typehint was confusing for users. Also, some of the code (and documentation) was using the literal 'terminate' whereas other parts were using 'all'; this makes it all consistent.

## ✔️ Checklist
- [ ] Unit and integration tests passing.
- [x] Pre-commit hooks passing.
- [ ] Quality checks passing.
- [x] Updated the [documentation](https://github.com/simvue-io/docs).
