### PR TITLE
Fix serializer typing

### DIFF
--- a/simvue/models.py
+++ b/simvue/models.py
@@ -101,7 +101,9 @@ class GridMetricSet(pydantic.BaseModel):
     metric: str
 
     @pydantic.field_serializer("array", when_used="always")
-    def serialize_array(self, value: numpy.ndarray | list[float], *_) -> list[float]:
+    def serialize_array(
+        self, value: numpy.ndarray | list[float] | list[list[float]], *_
+    ) -> list[float] | list[list[float]]:
         if isinstance(value, list):
             return value
         return value.tolist()


### PR DESCRIPTION
# Fix GridMetrics serializer typing

**Python Version(s) Tested:** 3.10

**Operating System(s):** Ubuntu 22.04

## 📝 Summary

`serialize_array` in `GridMetricSet` has the wrong typing - doesnt include `list[list[float]]` as an option in the inputs and return type

## 🔍 Diagnosis

Lots of these warnings printed:
```
  PydanticSerializationUnexpectedValue(Expected `float` - serialized value may not be as expected [input_value=[20.0, 20.0, 20.0, 20.0, ... 20.0, 20.0, 20.0, 20.0], input_type=list])
```
## 🔄 Changes

Add correct typing

## ✔️ Checklist
- [x] Unit and integration tests passing.
- [x] Pre-commit hooks passing.
- [x] Quality checks passing.
