### PR TITLE
🐛 Ensure only valid arguments are sent to the server

### DIFF
--- a/simvue/api/objects/alert/base.py
+++ b/simvue/api/objects/alert/base.py
@@ -31,6 +31,7 @@ class AlertBase(SimvueObject):
         """Retrieve an alert from the Simvue server by identifier"""
         self._label = "alert"
         super().__init__(identifier=identifier, **kwargs)
+        self._local_only_args = ["frequency", "pattern", "aggregation"]
 
     def compare(self, other: "AlertBase") -> bool:
         """Compare this alert to another"""

--- a/simvue/api/objects/alert/metrics.py
+++ b/simvue/api/objects/alert/metrics.py
@@ -30,6 +30,12 @@ class MetricsThresholdAlert(AlertBase):
         """Connect to a local or remote threshold alert by identifier"""
         self.alert = MetricThresholdAlertDefinition(self)
         super().__init__(identifier, **kwargs)
+        self._local_only_args += [
+            "rule",
+            "window",
+            "metric",
+            "threshold",
+        ]
 
     @classmethod
     def get(
@@ -117,6 +123,13 @@ class MetricsRangeAlert(AlertBase):
         """Connect to a local or remote threshold alert by identifier"""
         self.alert = MetricRangeAlertDefinition(self)
         super().__init__(identifier, **kwargs)
+        self._local_only_args += [
+            "rule",
+            "window",
+            "metric",
+            "range_low",
+            "range_high",
+        ]
 
     def compare(self, other: "MetricsRangeAlert") -> bool:
         """Compare two MetricRangeAlerts"""

--- a/simvue/api/objects/artifact/base.py
+++ b/simvue/api/objects/artifact/base.py
@@ -54,6 +54,7 @@ class ArtifactBase(SimvueObject):
         self._label = "artifact"
         self._endpoint = f"{self._label}s"
         super().__init__(identifier=identifier, _read_only=_read_only, **kwargs)
+        self._local_only_args += ["storage", "file_path", "runs"]
 
         # If the artifact is an online instance, need a place to store the response
         # from the initial creation

--- a/simvue/api/objects/base.py
+++ b/simvue/api/objects/base.py
@@ -197,6 +197,12 @@ class SimvueObject(abc.ABC):
         self._read_only: bool = _read_only
         self._is_set: bool = False
         self._endpoint: str = getattr(self, "_endpoint", f"{self._label}s")
+
+        # For simvue object initialisation, unlike the server there is no nested
+        # arguments, however this means that there are extra keys during post which
+        # need removing, this attribute handles that and should be set in subclasses.
+        self._local_only_args: list[str] = []
+
         self._identifier: str | None = (
             identifier if identifier is not None else f"offline_{uuid.uuid1()}"
         )
@@ -633,6 +639,10 @@ class SimvueObject(abc.ABC):
         if not is_json:
             kwargs = msgpack.packb(data or kwargs, use_bin_type=True)
 
+        # Remove any extra keys
+        for key in self._local_only_args:
+            _ = (data or kwargs).pop(key, None)
+
         _response = sv_post(
             url=f"{self._base_url}",
             headers=self._headers | {"Content-Type": "application/msgpack"},
@@ -670,6 +680,11 @@ class SimvueObject(abc.ABC):
     def _put(self, **kwargs) -> dict[str, typing.Any]:
         if not self.url:
             raise RuntimeError(f"Identifier for instance of {self._label} Unknown")
+
+        # Remove any extra keys
+        for key in self._local_only_args:
+            _ = kwargs.pop(key, None)
+
         _response = sv_put(
             url=f"{self.url}", headers=self._headers, data=kwargs, is_json=True
         )

--- a/simvue/run.py
+++ b/simvue/run.py
@@ -766,7 +766,6 @@ class Run:
         self._sv_obj.alerts = []
         self._sv_obj.created = time.time()
         self._sv_obj.notifications = notification
-        self._sv_obj._staging["folder_id"] = self._folder.id
 
         if self._status == "running":
             self._sv_obj.system = get_system()


### PR DESCRIPTION
# Fix Invalid Arguments being sent to Server

**Issue:** N/A

**Python Version(s) Tested:** 3.14

**Operating System(s):** Ubuntu 24.05

## 📝 Summary

The server now forbids unrecognised arguments in requests, the Python API until this point was sending such arguments.

## 🔍 Diagnosis

Error 422 now sent by server. Due to the way the LLAPI works arguments are provided at a single level whereas the server uses nested arguments for, e.g. alerts. Until now all arguments were sent to the server and the extra ignored but now the server will throw an error.

## 🔄 Changes

Patched by adding an internal attribute to `SimvueObject` which lists which keys/attributes present in the staging for the class instance should not be sent to the server.

## ✔️ Checklist
- [ ] Unit and integration tests passing.
- [ ] Pre-commit hooks passing.
- [ ] Quality checks passing.
