### PR TITLE
🐛 Ensure GridMetrics are sent with msgpack

### DIFF
--- a/simvue/api/objects/grids.py
+++ b/simvue/api/objects/grids.py
@@ -8,6 +8,7 @@ a new grid given relevant arguments.
 """
 
 import http
+import msgpack
 import numpy
 import typing
 
@@ -373,8 +374,9 @@ class GridMetrics(SimvueObject):
 
         _response = sv_post(
             url=f"{self._user_config.server.url}/{self.run_grids_endpoint(self._run_id)}",
-            headers=self._headers,
-            data=metrics,
+            headers=self._headers | {"Content-Type": "application/msgpack"},
+            data=msgpack.packb(metrics, use_bin_type=True),
+            is_json=False,
             params={},
         )
 

--- a/tests/unit/test_grids.py
+++ b/tests/unit/test_grids.py
@@ -47,7 +47,7 @@ def test_grid_creation_online() -> None:
 
 @pytest.mark.api
 @pytest.mark.offline
-def test_grid_creation_offline() -> None:
+def test_grid_creation_offline(offline_cache_setup) -> None:
     _uuid: str = f"{uuid.uuid4()}".split("-")[0]
     _folder_name = f"/simvue_unit_testing/{_uuid}"
     _folder = Folder.new(path=_folder_name, offline=True)
@@ -141,7 +141,7 @@ def test_grid_metrics_creation_online() -> None:
 
 @pytest.mark.api
 @pytest.mark.offline
-def test_grid_metrics_creation_offline() -> None:
+def test_grid_metrics_creation_offline(offline_cache_setup) -> None:
     _uuid: str = f"{uuid.uuid4()}".split("-")[0]
     _folder_name = f"/simvue_unit_testing/{_uuid}"
     _folder = Folder.new(path=_folder_name, offline=True)


### PR DESCRIPTION
Ensures that objects of type `GridMetrics` are sent to the server via `msgpack`.
