### PR TITLE
Remove extra arguments from object creation

### DIFF
--- a/simvue/api/objects/alert/base.py
+++ b/simvue/api/objects/alert/base.py
@@ -31,7 +31,12 @@ class AlertBase(SimvueObject):
         """Retrieve an alert from the Simvue server by identifier"""
         self._label = "alert"
         super().__init__(identifier=identifier, **kwargs)
-        self._local_only_args = ["frequency", "pattern", "aggregation"]
+        self._local_only_args = [
+            "frequency",
+            "pattern",
+            "aggregation",
+            "status",
+        ]
 
     def compare(self, other: "AlertBase") -> bool:
         """Compare this alert to another"""

--- a/simvue/api/objects/base.py
+++ b/simvue/api/objects/base.py
@@ -201,7 +201,7 @@ class SimvueObject(abc.ABC):
         # For simvue object initialisation, unlike the server there is no nested
         # arguments, however this means that there are extra keys during post which
         # need removing, this attribute handles that and should be set in subclasses.
-        self._local_only_args: list[str] = []
+        self._local_only_args: list[str] = ["created"]
 
         self._identifier: str | None = (
             identifier if identifier is not None else f"offline_{uuid.uuid1()}"
@@ -636,12 +636,12 @@ class SimvueObject(abc.ABC):
     def _post_single(
         self, *, is_json: bool = True, data: list | dict | None = None, **kwargs
     ) -> dict[str, typing.Any] | list[dict[str, typing.Any]]:
-        if not is_json:
-            kwargs = msgpack.packb(data or kwargs, use_bin_type=True)
-
         # Remove any extra keys
         for key in self._local_only_args:
             _ = (data or kwargs).pop(key, None)
+
+        if not is_json:
+            kwargs = msgpack.packb(data or kwargs, use_bin_type=True)
 
         _response = sv_post(
             url=f"{self._base_url}",

--- a/simvue/api/objects/storage/s3.py
+++ b/simvue/api/objects/storage/s3.py
@@ -27,6 +27,13 @@ class S3Storage(StorageBase):
         """Initialise an S3Storage instance attaching a configuration"""
         self.config = Config(self)
         super().__init__(identifier, **kwargs)
+        self._local_only_args: list[str] = [
+            "endpoint_url",
+            "region_name",
+            "access_key_id",
+            "secret_access_key",
+            "bucket",
+        ]
 
     @classmethod
     @pydantic.validate_call


### PR DESCRIPTION
# Fix Extra arguments error from server

**Issue:** N/A

**Python Version(s) Tested:** 3.14

**Operating System(s):** Ubuntu 24.10

## 📝 Summary

Prevent server validation errors.

## 🔍 Diagnosis

Server raises `422` error when extra parameters are sent in a request.

## 🔄 Changes

Adds additional arguments to `_local_args` to remove them from the data sent to the server on object creation since the tightening of validation.

## ✔️ Checklist
- [x] Unit and integration tests passing.
- [x] Pre-commit hooks passing.
- [x] Quality checks passing.
