### PR TITLE
Fix inconsistency in grid definition

### DIFF
--- a/simvue/run.py
+++ b/simvue/run.py
@@ -1688,7 +1688,9 @@ class Run:
                         + "using default axis range [0, 1] for all axes "
                         + "and assuming constant interval."
                     )
-                    _axes_ticks = [numpy.linspace(0, 1, n) for n in metric.shape]
+                    _axes_ticks = [
+                        numpy.linspace(0, 1, n) for n in reversed(metric.shape)
+                    ]
                     self.assign_metric_to_grid(
                         metric_name=label,
                         grid_name=label,

--- a/tests/functional/test_run_class.py
+++ b/tests/functional/test_run_class.py
@@ -297,6 +297,16 @@ def test_log_metrics_online(
 
 
 @pytest.mark.run
+@pytest.mark.online
+def test_log_grid_metric_auto_grid() -> None:
+    with sv_run.Run() as run_final:
+        run_final.init("test")
+        run_final.log_metrics({"test": numpy.ones((20, 30))}) # see issue #921
+        time.sleep(1)
+
+
+
+@pytest.mark.run
 @pytest.mark.offline
 @pytest.mark.parametrize("metric_type", ("regular", "tensor"))
 def test_log_metrics_offline(
@@ -318,7 +328,7 @@ def test_log_metrics_offline(
         )
     else:
         METRICS = {"a": 10, "aB0-_/.:=><+()": 1.2, "c": 2}
-        
+
     run.log_metrics(METRICS)
     
     time.sleep(1)


### PR DESCRIPTION
# Fix ordering when creating automatic 

**Issue:** https://github.com/simvue-io/python-api/issues/921

**Python Version(s) Tested:** 3.13

**Operating System(s):** Ubuntu 25.10

## 📝 Summary

Auto-grids were created with the wrong axis ordering.

## 🔍 Diagnosis

Found when logging  a grid metric without providing a grid upfront:
```python
run.log_metrics({"test": numpy.ones((20, 30))})
```

## 🔄 Changes

Simple reversal `reversed(array.shape)` when using array shape for axes intervals.

## ✔️ Checklist
- [ ] Unit and integration tests passing.
- [ ] Pre-commit hooks passing.
- [ ] Quality checks passing.
