### PR TITLE
Fix set_metric_units docstring in run.py that named a non-existent parameter

### DIFF
--- a/simvue/run.py
+++ b/simvue/run.py
@@ -2669,8 +2669,6 @@ class Run:
             name of metric to assign units to
         units : str
             unit symbol
-        label : str | None, optional
-            alternative longer name for units
         """
         self._meta_cache.setdefault("metrics", {})
 


### PR DESCRIPTION
Fix set_metric_units docstring in run.py that named a non-existent parameter

## 📝 Summary

Docstring documented `label` that was not a paremeter, so reference api generation in the docs repo was failing

## 🔄 Changes

Remove `label` from docstring

## ✔️ Checklist
- [x] Unit and integration tests ~~passing~~ unchanged.
- [x] Pre-commit hooks ~~passing~~ unchanged.
- [x] Quality checks ~~passing~~ unchanged.
