### PR TITLE
Remove completion trigger windows restriction

### DIFF
--- a/simvue/executor.py
+++ b/simvue/executor.py
@@ -207,8 +207,6 @@ class Executor:
             ...
         ```
 
-        Note `completion_trigger` is not supported on Windows operating systems.
-
         Parameters
         ----------
         identifier : str
@@ -229,7 +227,7 @@ class Executor:
         completion_callback : typing.Callable | None, optional
             callback to run when process terminates
         completion_trigger : threading.Event | None, optional
-            this trigger event is set when the processes completes (not supported on Windows)
+            this trigger event is set when the processes completes
         """
         pos_args = list(args)
 

--- a/simvue/executor.py
+++ b/simvue/executor.py
@@ -10,7 +10,6 @@ __date__ = "2023-11-15"
 
 import logging
 import multiprocessing.synchronize
-import sys
 import threading
 import os
 import shutil
@@ -236,12 +235,6 @@ class Executor:
 
         if not self._runner.name:
             raise RuntimeError("Cannot add process, expected Run instance to have name")
-
-        if sys.platform == "win32" and completion_trigger:
-            logger.warning(
-                "Completion trigger for 'add_process' may fail on Windows "
-                "due to function pickling restrictions"
-            )
 
         # To check the executable provided by the user exists combine with environment
         # PATH variable if exists, if not provided use the current environment

--- a/simvue/run.py
+++ b/simvue/run.py
@@ -875,8 +875,6 @@ class Run:
         def callback_function(status_code: int, std_out: str, std_err: str) -> None: ...
         ```
 
-        Note `completion_callback` is not supported on Windows operating systems.
-
         Alternatively you can use `completion_trigger` to create a multiprocessing event which will be set
         when the process has completed.
 
@@ -896,7 +894,7 @@ class Run:
             the input file to run, note this only work if the input file is not an option, if this is the case
             you should provide it as such and perform the upload manually, by default None
         completion_callback : typing.Callable | None, optional
-            callback to run when process terminates (not supported on Windows)
+            callback to run when process terminates
         completion_trigger : threading.Event | None, optional
             this trigger event is set when the processes completes
         env : dict[str, str], optional

--- a/simvue/run.py
+++ b/simvue/run.py
@@ -25,7 +25,6 @@ import traceback as tb
 import time
 import types
 import functools
-import platform
 import typing
 import uuid
 import numpy
@@ -939,12 +938,6 @@ class Run:
             warnings.warn(
                 "Use of a 'multiprocessing.Event' as a termination trigger will be deprecated in v2.5, "
                 + "use an instance of 'threading.Event' instead."
-            )
-
-        if platform.system() == "Windows" and completion_trigger:
-            raise RuntimeError(
-                "Use of 'completion_trigger' on Windows based operating systems is unsupported "
-                "due to function pickling restrictions for multiprocessing"
             )
 
         if isinstance(executable, pathlib.Path) and not executable.is_file():

--- a/tests/functional/test_executor.py
+++ b/tests/functional/test_executor.py
@@ -58,9 +58,8 @@ def test_executor_add_process(
 
 
 @pytest.mark.executor
-@pytest.mark.unix
 def test_executor_multiprocess(request: pytest.FixtureRequest) -> None:
-    triggers: dict[int, multiprocessing.synchronize.Event] = {}
+    triggers: dict[int, threading.Event] = {}
     callbacks: dict[int, typing.Callable] = {}
     events: dict[int, bool] = {}
     folder_id = f"{uuid.uuid4()}".split("-")[0]
@@ -180,7 +179,6 @@ def test_completion_callbacks_var_change(request: pytest.FixtureRequest) -> None
         folder.delete(recursive=True, delete_runs=True)
 
 @pytest.mark.executor
-@pytest.mark.unix
 def test_completion_trigger_set(request: pytest.FixtureRequest) -> None:
     trigger = threading.Event()
     folder_id = f"{uuid.uuid4()}".split("-")[0]

--- a/tests/functional/test_executor.py
+++ b/tests/functional/test_executor.py
@@ -80,10 +80,21 @@ def test_executor_multiprocess(request: pytest.FixtureRequest) -> None:
                 triggers[i] = threading.Event()
                 callbacks[i] = callback
                 out_file = pathlib.Path(tempd).joinpath(f"out_file_{i}.dat")
+                if sys.platform == "win32":
+                    executable = "powershell"
+                    c = (
+                        f'for ($i = 0; $i -le 10; $i++) {{ '
+                        f'Start-Sleep -Milliseconds 500; '
+                        f'Add-Content -Path "{out_file}" -Value $i '
+                        f'}}'
+                    )
+                else:
+                    executable = "bash"
+                    c = f'for i in {{0..10}}; do sleep 0.5; echo "$i" >> "{out_file}"; done'
                 run.add_process(
                     f"cmd_{i}_{os.environ.get('PYTEST_XDIST_WORKER', 0)}",
-                    executable="bash",
-                    c="for i in {0..10}; do sleep 0.5; echo $i >> "+ f"{out_file}; done",
+                    executable=executable,
+                    c=c,
                     completion_trigger=triggers[i],
                     completion_callback=callbacks[i]
                 )


### PR DESCRIPTION
# Remove completion trigger windows restriction

## 📝 Summary
If you try to use completion trigger on Windows, it will throw you back an error saying the feature is disabled due to function pickling restrictions. This must be a hangover from a previous implementation, since there is now no pickling involved in the executor. Removing this guard to see if it works

## 🔍 Diagnosis
Found when developing new tutorials on building connectors
## 🔄 Changes
Remove guard, remove unix marks from tests
## ✔️ Checklist
- [x] Unit and integration tests passing.
- [x] Pre-commit hooks passing.
- [x] Quality checks passing.
