### PR TITLE
Remove deduplication from client side

### DIFF
--- a/simvue/api/objects/alert/user.py
+++ b/simvue/api/objects/alert/user.py
@@ -101,7 +101,7 @@ class UserAlert(AlertBase):
             token for alternative server, default None
 
         """
-        return cls(
+        _alert = cls(
             name=name,
             description=description,
             notification=notification,
@@ -109,10 +109,11 @@ class UserAlert(AlertBase):
             enabled=enabled,
             server_url=server_url,
             server_token=server_token,
-            _params={"deduplicate": True},
             _read_only=False,
             _offline=offline,
         )
+        _alert._params = {"deduplicate": True}
+        return _alert
 
     @override
     def _compare_objects(self, other: "AlertBase") -> bool:

--- a/simvue/run.py
+++ b/simvue/run.py
@@ -76,9 +76,6 @@ try:
 except ImportError:
     from typing_extensions import Self
 
-if typing.TYPE_CHECKING:
-    from simvue.api.objects.alert.base import AlertBase
-
 
 HEARTBEAT_INTERVAL: int = 60
 RESOURCES_METRIC_PREFIX: str = "resources"
@@ -2314,18 +2311,6 @@ class Run:
 
         return True
 
-    def _check_if_alert_exists(self, alert: "AlertBase") -> str | None:
-        """Check if an existing alert matches definition."""
-        # If the alert already exists just add the existing one
-        for _id, _existing_alert in Alert.get(
-            offline=self.mode == "offline",
-            server_url=self._user_config.server.url,
-            server_token=self._user_config.server.token,
-        ):
-            if _existing_alert == alert:
-                return _id
-        return None
-
     @skip_if_failed("_aborted", "_suppress_errors", on_failure_return=None)
     @pydantic.validate_call
     def create_metric_range_alert(
@@ -2409,12 +2394,6 @@ class Run:
             server_url=self._user_config.server.url,
             server_token=self._user_config.server.token,
         )
-
-        # If the alert already exists just add the existing one
-        if _existing_id := self._check_if_alert_exists(_alert):
-            if attach_to_run:
-                self.add_alerts(ids=[_existing_id])
-            return _existing_id
 
         _alert.abort = trigger_abort
         _alert.commit()
@@ -2503,12 +2482,6 @@ class Run:
             server_token=self._user_config.server.token,
         )
 
-        # If the alert already exists just add the existing one
-        if _existing_id := self._check_if_alert_exists(_alert):
-            if attach_to_run:
-                self.add_alerts(ids=[_existing_id])
-            return _existing_id
-
         _alert.abort = trigger_abort
         _alert.commit()
         if attach_to_run:
@@ -2568,12 +2541,6 @@ class Run:
             server_token=self._user_config.server.token,
         )
 
-        # If the alert already exists just add the existing one
-        if _existing_id := self._check_if_alert_exists(_alert):
-            if attach_to_run:
-                self.add_alerts(ids=[_existing_id])
-            return _existing_id
-
         _alert.abort = trigger_abort
         _alert.commit()
 
@@ -2626,12 +2593,6 @@ class Run:
             server_url=self._user_config.server.url,
             server_token=self._user_config.server.token,
         )
-
-        # If the alert already exists just add the existing one
-        if _existing_id := self._check_if_alert_exists(_alert):
-            if attach_to_run:
-                self.add_alerts(ids=[_existing_id])
-            return _existing_id
 
         _alert.abort = trigger_abort
         _alert.commit()


### PR DESCRIPTION
Alert deduplication is handled by the server, with a 409 response and the deduplicated ID being returned. Have just removed any attempt at deduplication from the client, since this was giving errors in offline mode.

Note that there is a failing test due to user deduplication not working on the server - Andrew is looking at this