### PR TITLE
Remove inspecting JSON output when downloading file data

### DIFF
--- a/simvue/api/objects/artifact/base.py
+++ b/simvue/api/objects/artifact/base.py
@@ -409,7 +409,9 @@ class ArtifactBase(SimvueObject):
                 f"Could not retrieve URL for artifact '{self._identifier}'",
             )
 
-        _timeout = BASE_TIMEOUT + DOWNLOAD_TIMEOUT_PER_MB * self.size / 1024 / 1024
+        _timeout: int = int(
+            BASE_TIMEOUT + DOWNLOAD_TIMEOUT_PER_MB * self.size / 1024 // 1024
+        )
 
         self._logger.debug(
             "Will wait %s for download of file %s of size %s",
@@ -425,12 +427,12 @@ class ArtifactBase(SimvueObject):
             headers=None,
         )
 
-        get_json_from_response(
-            response=_response,
-            allow_parse_failure=True,
-            expected_status=[http.HTTPStatus.OK],
-            scenario=f"Retrieval of file for {self.label()} '{self._identifier}'",
-        )
+        if _response.status_code != http.HTTPStatus.OK:
+            raise RuntimeError(
+                f"Retrieval of file date for {self.label()} '{self._identifier}' "
+                + f"failed for url '{self.download_url}' "
+                + f"with status code {_response.status_code}"
+            )
 
         _total_length: str | None = _response.headers.get("content-length")
 


### PR DESCRIPTION
# Fix Memory Issue when Downloading File Data

**Issue:** https://github.com/simvue-io/python-api/issues/990

**Python Version(s) Tested:** Python 3.14

**Operating System(s):** Ubuntu 26.04

## 📝 Summary

Addresses issue where there was a memory leak caused by streaming of all JSON data during download of files.

## 🔍 Diagnosis

See issue.

## 🔄 Changes

Removed unused call to `get_json_response` and instead performed response checks on just HTTP status code.

## ✔️ Checklist
- [ ] Unit and integration tests passing.
- [ ] Pre-commit hooks passing.
- [ ] Quality checks passing.
