### PR TITLE
Added handling of case where shell cannot be found in add_process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## Unreleased
+
+- Fix case where shell cannot be found for `add_process`.
+- Fix UTC compatibility for Python 3.10.
+- Added retrieval of server version in `Sender`.
+- Fixed memory issue when downloading large data files.
+- Fixed incorrect exception catch for JSON responses.
+
 ## [v2.5.9](https://github.com/simvue-io/python-api/releases/tag/v2.5.9) - 2026-06-26
 
 - Fixed bug with error handling in logging handler

--- a/simvue/executor.py
+++ b/simvue/executor.py
@@ -35,7 +35,7 @@ class CompletionCallback(typing.Protocol):
 
 
 def get_current_shell() -> str | None:
-    """Return the users current shell executable."""
+    """Return the users current shell executable if found."""
     try:
         _process = psutil.Process(os.getppid())
         return os.environ.get("SHELL", _process.exe())
@@ -156,7 +156,7 @@ class Executor:
     def _kwarg_assembly(kwargs, executable: str | None) -> list[str]:
         _arguments: list[str] = []
         _shell_is_pwsh: bool = any(
-            shell in get_current_shell() for shell in ("pwsh", "powershell")
+            shell in (get_current_shell() or "") for shell in ("pwsh", "powershell")
         )
         _exec_is_pwsh: bool = executable in {"pwsh", "powershell", None}
         _use_pwsh: bool = _shell_is_pwsh and _exec_is_pwsh


### PR DESCRIPTION
# Fix Shell not found for `add_process`

**Issue:** https://github.com/simvue-io/python-api/issues/997

**Python Version(s) Tested:** 3.14

**Operating System(s):** Ubuntu 26.04

## 📝 Summary

Fixes an issue where `get_current_shell` returns `None` and therefore `None` is used in a string check.

## 🔍 Diagnosis

Execution of code on Apptainer via HPC systems leads to no shell being identified.

## 🔄 Changes

Modified comparison to `if any(shell in (get_current_shell() or "") for shell in ('pwsh', 'powershell')):`.

## ✔️ Checklist
- [ ] Unit and integration tests passing.
- [ ] Pre-commit hooks passing.
- [ ] Quality checks passing.
